### PR TITLE
Fix brightness when starting tile animations

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -180,14 +180,22 @@ public class LightViewModel extends DeviceViewModel {
 	 *
 	 * @param animationData Data for the animation.
 	 */
-	public void startAnimation(final AnimationData animationData) {
-		Context context = getContext().get();
-		if (context == null) {
-			return;
-		}
-		mAnimationStatus.postValue(true);
-		LifxAnimationService.triggerAnimationService(context, getLight(), animationData);
-	}
+        public void startAnimation(final AnimationData animationData) {
+                Context context = getContext().get();
+                if (context == null) {
+                        return;
+                }
+                // Make sure the brightness of the light matches the currently selected
+                // brightness before starting the animation.  For some lights (e.g. tiles
+                // without chain support) the device does not properly apply brightness
+                // changes while an effect is running unless the full color information is
+                // sent ahead of time.  Calling updateBrightness here ensures that the
+                // brightness is set accordingly for native effects.
+                updateBrightness(AnimationData.getSelectedBrightness(getLight()));
+
+                mAnimationStatus.postValue(true);
+                LifxAnimationService.triggerAnimationService(context, getLight(), animationData);
+        }
 
 	/**
 	 * Stop the animation.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredAnimation.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredAnimation.java
@@ -131,16 +131,20 @@ public class StoredAnimation extends StoredColor {
 				new Drawable[]{getAnimationData().getBaseButtonDrawable(context, getLight(), getRelativeBrightness()), animationDrawable});
 	}
 
-	@Override
-	protected final void setColor(final int colorDuration, final MainViewModel model) {
-		if (model instanceof LightViewModel) {
-			((LightViewModel) model).startAnimation(mAnimationData);
-			((LightViewModel) model).updateSelectedBrightness(mRelativeBrightness);
-		}
-		else {
-			PreferenceUtil.setIndexedSharedPreferenceDouble(R.string.key_device_selected_brightness, getDeviceId(), getRelativeBrightness());
-			LifxAnimationService.triggerAnimationService(Application.getAppContext(), getLight(), mAnimationData);
-		}
-	}
+        @Override
+        protected final void setColor(final int colorDuration, final MainViewModel model) {
+                if (model instanceof LightViewModel) {
+                        // Ensure that the desired brightness is stored and applied before
+                        // the animation starts.  Updating the selected brightness first
+                        // allows the model's startAnimation call to pick up the new value
+                        // and transmit the full color information if necessary.
+                        ((LightViewModel) model).updateSelectedBrightness(mRelativeBrightness);
+                        ((LightViewModel) model).startAnimation(mAnimationData);
+                }
+                else {
+                        PreferenceUtil.setIndexedSharedPreferenceDouble(R.string.key_device_selected_brightness, getDeviceId(), getRelativeBrightness());
+                        LifxAnimationService.triggerAnimationService(Application.getAppContext(), getLight(), mAnimationData);
+                }
+        }
 
 }


### PR DESCRIPTION
## Summary
- ensure selected brightness is applied to the light before launching animations
- apply stored brightness before starting a stored animation

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aae5d38a0c832294dc3024db563a89