### PR TITLE
Refine tile chain effect drawables

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainClouds.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainClouds.java
@@ -3,13 +3,15 @@ package de.jeisfeld.lifx.app.animation;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.LayerDrawable;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import androidx.core.content.ContextCompat;
 import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.util.ColorUtil;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
 import de.jeisfeld.lifx.lan.Light;
 import de.jeisfeld.lifx.lan.Light.AnimationDefinition;
@@ -143,8 +145,34 @@ public class TileChainClouds extends AnimationData {
 		};
 	}
 
-	@Override
-	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {
-		return ContextCompat.getDrawable(context, R.drawable.flame);
-	}
+        @Override
+        public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {
+                int size = (int) context.getResources().getDimension(R.dimen.power_button_size);
+                int strokeSize = (int) context.getResources().getDimension(R.dimen.power_button_stroke_size);
+
+                Color baseColor = mColors.get(0).withRelativeBrightness(relativeBrightness);
+
+                GradientDrawable base = new GradientDrawable();
+                base.setShape(GradientDrawable.RECTANGLE);
+                base.setColor(ColorUtil.toAndroidDisplayColor(baseColor));
+                base.setStroke(strokeSize, android.graphics.Color.BLACK);
+                base.setSize(size, size);
+
+                Color cloudColor = baseColor.add(Color.WHITE, 0.5);
+                GradientDrawable cloud1 = new GradientDrawable();
+                cloud1.setShape(GradientDrawable.OVAL);
+                cloud1.setSize(size / 2, size / 3);
+                cloud1.setColor(ColorUtil.toAndroidDisplayColor(cloudColor));
+
+                GradientDrawable cloud2 = new GradientDrawable();
+                cloud2.setShape(GradientDrawable.OVAL);
+                cloud2.setSize(size / 3, size / 4);
+                cloud2.setColor(ColorUtil.toAndroidDisplayColor(cloudColor));
+
+                LayerDrawable layerDrawable = new LayerDrawable(new Drawable[] {base, cloud1, cloud2});
+                layerDrawable.setLayerInset(1, size / 8, size / 4, size / 3, size / 4);
+                layerDrawable.setLayerInset(2, size / 2, size / 3, size / 6, size / 6);
+
+                return layerDrawable;
+        }
 }

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainFlame.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainFlame.java
@@ -3,6 +3,8 @@ package de.jeisfeld.lifx.app.animation;
 import android.content.Context;
 import android.content.Intent;
 import android.graphics.drawable.Drawable;
+import android.graphics.ColorMatrix;
+import android.graphics.ColorMatrixColorFilter;
 
 import java.io.IOException;
 
@@ -123,8 +125,13 @@ public class TileChainFlame extends AnimationData {
 		};
 	}
 
-	@Override
-	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {
-		return ContextCompat.getDrawable(context, R.drawable.flame);
-	}
+        @Override
+        public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {
+                Drawable drawable = ContextCompat.getDrawable(context, R.drawable.flame).mutate();
+                float brightness = (float) relativeBrightness;
+                ColorMatrix colorMatrix = new ColorMatrix();
+                colorMatrix.setScale(brightness, brightness, brightness, 1f);
+                drawable.setColorFilter(new ColorMatrixColorFilter(colorMatrix));
+                return drawable;
+        }
 }


### PR DESCRIPTION
## Summary
- Render cloud preview using first animation color with lighter cloud overlays
- Allow flame preview brightness to scale with relative brightness factor

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68ab918e8f008322a38a7bc3ecc27391