### PR TITLE
Add scenes feature for configurable light sequences

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/MainActivity.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/MainActivity.java
@@ -71,10 +71,10 @@ public class MainActivity extends AppCompatActivity {
 		NavigationView navigationView = findViewById(R.id.nav_view);
 		// Passing each menu ID as a set of Ids because each
 		// menu should be considered as top level destinations.
-		mAppBarConfiguration = new Builder(R.id.nav_home, R.id.nav_manage_devices, R.id.nav_stored_colors,
-				R.id.nav_alarms, R.id.nav_settings)
-				.setOpenableLayout(drawer)
-				.build();
+                mAppBarConfiguration = new Builder(R.id.nav_home, R.id.nav_manage_devices, R.id.nav_stored_colors,
+                                R.id.nav_alarms, R.id.nav_scenes, R.id.nav_settings)
+                                .setOpenableLayout(drawer)
+                                .build();
 		NavController navController = Navigation.findNavController(this, R.id.nav_host_fragment);
 		NavigationUI.setupActionBarWithNavController(this, navController, mAppBarConfiguration);
 		NavigationUI.setupWithNavController(navigationView, navController);

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
@@ -21,9 +21,11 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Date;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 import java.util.concurrent.TimeUnit;
 
 import androidx.core.app.NotificationCompat;
@@ -36,6 +38,8 @@ import de.jeisfeld.lifx.app.alarms.Alarm.AlarmType;
 import de.jeisfeld.lifx.app.alarms.Alarm.LightSteps;
 import de.jeisfeld.lifx.app.alarms.Alarm.RingtoneStep;
 import de.jeisfeld.lifx.app.alarms.Alarm.Step;
+import de.jeisfeld.lifx.app.scenes.Scene;
+import de.jeisfeld.lifx.app.scenes.SceneRegistry;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
 import de.jeisfeld.lifx.app.storedcolors.StoredColor;
 import de.jeisfeld.lifx.app.storedcolors.StoredMultizoneColors;
@@ -89,7 +93,8 @@ public class LifxAlarmService extends Service {
 	/**
 	 * Action for testing an alarm.
 	 */
-	protected static final String ACTION_TEST_ALARM = "de.jeisfeld.lifx.app.ACTION_TEST_ALARM";
+    protected static final String ACTION_TEST_ALARM = "de.jeisfeld.lifx.app.ACTION_TEST_ALARM";
+    protected static final String ACTION_TEST_SCENE = "de.jeisfeld.lifx.app.ACTION_TEST_SCENE";
 	/**
 	 * Action for interrupting an alarm.
 	 */
@@ -203,9 +208,17 @@ public class LifxAlarmService extends Service {
 			runAnimations(alarm, alarmDate);
 			AlarmReceiver.retriggerAlarm(this, alarm);
 		}
-		else if (ACTION_TEST_ALARM.equals(action)) {
-			runAnimations(alarm, alarmDate);
-		}
+        else if (ACTION_TEST_ALARM.equals(action)) {
+                        runAnimations(alarm, alarmDate);
+                }
+                else if (ACTION_TEST_SCENE.equals(action)) {
+                        Scene scene = SceneRegistry.getInstance().getScene(alarmId);
+                        Alarm sceneAlarm = new Alarm(scene.getId(), true, alarmDate,
+                                        new HashSet<>(), scene.getName(),
+                                        scene.getSteps().stream().map(s -> new Step(s.getId(), s.getDelay(), s.getStoredColorId(), s.getDuration())).collect(Collectors.toList()),
+                                        AlarmType.STANDARD, null, false);
+                        runAnimations(sceneAlarm, alarmDate);
+                }
 		else if (ACTION_INTERRUPT_ALARM.equals(action)) {
 			interruptAlarm(alarm);
 		}

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/Scene.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/Scene.java
@@ -1,0 +1,440 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.content.Context;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.storedcolors.ColorRegistry;
+import de.jeisfeld.lifx.app.storedcolors.StoredColor;
+import de.jeisfeld.lifx.app.util.PreferenceUtil;
+import de.jeisfeld.lifx.lan.Light;
+
+/**
+ * Class holding information about a scene.
+ */
+public class Scene {
+        /** The id for storage. */
+        private final int mId;
+        /** The scene name. */
+        private final String mName;
+        /** The scene steps. */
+        private final List<Step> mSteps;
+
+        /**
+         * Generate a scene.
+         *
+         * @param id    The id for storage
+         * @param name  The name
+         * @param steps The steps
+         */
+        public Scene(final int id, final String name, final List<Step> steps) {
+                mId = id;
+                mName = name;
+                mSteps = steps;
+        }
+
+        /**
+         * Generate a new scene without id.
+         *
+         * @param name  The name
+         * @param steps The steps
+         */
+        public Scene(final String name, final List<Step> steps) {
+                this(-1, name, steps);
+        }
+
+        /**
+         * Retrieve a scene from storage via id.
+         *
+         * @param sceneId The id.
+         */
+        public Scene(final int sceneId) {
+                mId = sceneId;
+                mName = PreferenceUtil.getIndexedSharedPreferenceString(R.string.key_scene_name, sceneId);
+                List<Integer> stepIds = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_scene_step_ids, sceneId);
+                mSteps = new ArrayList<>();
+                for (Integer stepId : stepIds) {
+                        if (stepId != null) {
+                                mSteps.add(new Step(stepId));
+                        }
+                }
+        }
+
+        /**
+         * Store this scene.
+         *
+         * @return the stored scene.
+         */
+        protected Scene store() {
+                Scene scene = this;
+                if (scene.getId() < 0) {
+                        int newId = PreferenceUtil.getSharedPreferenceInt(R.string.key_scene_max_id, 0) + 1;
+                        PreferenceUtil.setSharedPreferenceInt(R.string.key_scene_max_id, newId);
+                        List<Integer> sceneIds = PreferenceUtil.getSharedPreferenceIntList(R.string.key_scene_ids);
+                        sceneIds.add(newId);
+                        PreferenceUtil.setSharedPreferenceIntList(R.string.key_scene_ids, sceneIds);
+                        scene = new Scene(newId, getName(), getSteps());
+                }
+
+                PreferenceUtil.setIndexedSharedPreferenceString(R.string.key_scene_name, scene.getId(), scene.getName());
+
+                List<Step> newSteps = new ArrayList<>();
+                Collections.sort(scene.getSteps());
+                for (Step step : scene.getSteps()) {
+                        newSteps.add(step.store(scene.getId()));
+                }
+                scene.getSteps().clear();
+                scene.getSteps().addAll(newSteps);
+                return scene;
+        }
+
+        /**
+         * Get the id for storage.
+         *
+         * @return The id for storage.
+         */
+        public int getId() {
+                return mId;
+        }
+
+        /**
+         * Get the name.
+         *
+         * @return The name.
+         */
+        public String getName() {
+                return mName;
+        }
+
+        /**
+         * Get the steps.
+         *
+         * @return The steps.
+         */
+        public List<Step> getSteps() {
+                return mSteps;
+        }
+
+        /**
+         * Change the scene name.
+         *
+         * @param context The context
+         * @param name    The new name
+         * @return The updated scene
+         */
+        protected Scene withChangedName(final Context context, final String name) {
+                Scene newScene = new Scene(getId(), name, getSteps());
+                SceneRegistry.getInstance().addOrUpdate(newScene);
+                return newScene;
+        }
+
+        /**
+         * Get a list of LightSteps from the total list of steps.
+         *
+         * @return The lightsteps.
+         */
+        protected final List<LightSteps> getLightSteps() {
+                Collections.sort(getSteps());
+                List<LightSteps> result = new ArrayList<>();
+                for (Step step : getSteps()) {
+                        boolean found = false;
+                        Light light = step.getStoredColor().getLight();
+                        for (LightSteps lightSteps : result) {
+                                if (lightSteps.getLight().equals(light)) {
+                                        found = true;
+                                        lightSteps.getSteps().add(step);
+                                }
+                        }
+                        if (!found) {
+                                List<Step> newSteps = new ArrayList<>();
+                                newSteps.add(step);
+                                result.add(new LightSteps(light, newSteps));
+                        }
+                }
+                return result;
+        }
+
+        /**
+         * Remove a step from the scene.
+         *
+         * @param stepId The id of the step to remove.
+         */
+        protected void removeStep(final int stepId) {
+                Step remove = null;
+                for (Step step : getSteps()) {
+                        if (step.getId() == stepId) {
+                                remove = step;
+                                break;
+                        }
+                }
+                if (remove != null) {
+                        getSteps().remove(remove);
+                }
+        }
+
+        /**
+         * Update the duration of a step, shifting other steps accordingly.
+         *
+         * @param updatedStep The updated step.
+         */
+        protected void updateDuration(final Step updatedStep) {
+                List<Step> updatedSteps = new ArrayList<>();
+                for (LightSteps lightSteps : getLightSteps()) {
+                        if (updatedStep.getStoredColor().getLight().equals(lightSteps.getLight())) {
+                                boolean afterUpdatedStep = false;
+                                long durationDiff = 0;
+                                for (Step step : lightSteps.getSteps()) {
+                                        if (step.getId() == updatedStep.getId()) {
+                                                durationDiff = updatedStep.getDuration() - step.getDuration();
+                                                updatedSteps.add(updatedStep);
+                                                afterUpdatedStep = true;
+                                        }
+                                        else if (afterUpdatedStep) {
+                                                updatedSteps.add(step.withDelay(step.getDelay() + durationDiff));
+                                        }
+                                        else {
+                                                updatedSteps.add(step);
+                                        }
+                                }
+                        }
+                        else {
+                                updatedSteps.addAll(lightSteps.getSteps());
+                        }
+                }
+                getSteps().clear();
+                getSteps().addAll(updatedSteps);
+                Collections.sort(getSteps());
+        }
+
+        /**
+         * Update the delay of a step, shifting other steps accordingly.
+         *
+         * @param updatedStep The updated step.
+         */
+        protected void updateDelay(final Step updatedStep) {
+                List<Step> updatedSteps = new ArrayList<>();
+                for (LightSteps lightSteps : getLightSteps()) {
+                        if (updatedStep.getStoredColor().getLight().equals(lightSteps.getLight())) {
+                                boolean afterUpdatedStep = false;
+                                long delayDiff = 0;
+                                for (Step step : lightSteps.getSteps()) {
+                                        if (step.getId() == updatedStep.getId()) {
+                                                if (afterUpdatedStep) {
+                                                        delayDiff -= step.getDuration();
+                                                }
+                                                else {
+                                                        updatedSteps.add(updatedStep);
+                                                        afterUpdatedStep = true;
+                                                        delayDiff = updatedStep.getDelay() - step.getDelay();
+                                                }
+                                        }
+                                        else if (!afterUpdatedStep && step.getDelay() + step.getDuration() > updatedStep.getDelay()) {
+                                                updatedSteps.add(updatedStep);
+                                                afterUpdatedStep = true;
+                                                delayDiff = Math.max(0, updatedStep.getDelay() + updatedStep.getDuration() - step.getDelay());
+                                                updatedSteps.add(step.withDelay(step.getDelay() + delayDiff));
+                                        }
+                                        else {
+                                                updatedSteps.add(step.withDelay(step.getDelay() + delayDiff));
+                                        }
+                                }
+                        }
+                        else {
+                                updatedSteps.addAll(lightSteps.getSteps());
+                        }
+                }
+                getSteps().clear();
+                getSteps().addAll(updatedSteps);
+                Collections.sort(getSteps());
+        }
+
+        /**
+         * Class representing a step of a scene.
+         */
+        public static class Step implements Comparable<Step> {
+                /** The id for storage. */
+                private final int mId;
+                /** The step delay. */
+                private final long mDelay;
+                /** The stored color. */
+                private final int mStoredColorId;
+                /** The step duration. */
+                private final long mDuration;
+
+                /**
+                 * Generate a step.
+                 *
+                 * @param id            The id for storage
+                 * @param delay         the delay
+                 * @param storedColorId The stored color id
+                 * @param duration      the duration
+                 */
+                public Step(final int id, final long delay, final int storedColorId, final long duration) {
+                        mId = id;
+                        mDelay = delay;
+                        mStoredColorId = storedColorId;
+                        mDuration = duration;
+                }
+
+                /**
+                 * Generate a new step without id.
+                 *
+                 * @param delay         the delay
+                 * @param storedColorId The stored color id
+                 * @param duration      the duration
+                 */
+                public Step(final long delay, final int storedColorId, final long duration) {
+                        this(-1, delay, storedColorId, duration);
+                }
+
+                /**
+                 * Retrieve a step from storage via id.
+                 *
+                 * @param stepId The id
+                 */
+                protected Step(final int stepId) {
+                        mId = stepId;
+                        mDelay = PreferenceUtil.getIndexedSharedPreferenceLong(R.string.key_scene_step_delay, stepId, 0);
+                        mStoredColorId = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_scene_step_stored_color_id, stepId, 0);
+                        mDuration = PreferenceUtil.getIndexedSharedPreferenceLong(R.string.key_scene_step_duration, stepId, 0);
+                }
+
+                /**
+                 * Store this step.
+                 *
+                 * @param sceneId the scene id
+                 * @return the stored step
+                 */
+                public Step store(final int sceneId) {
+                        Step step = this;
+                        if (getId() < 0) {
+                                int newId = PreferenceUtil.getSharedPreferenceInt(R.string.key_scene_step_max_id, 0) + 1;
+                                PreferenceUtil.setSharedPreferenceInt(R.string.key_scene_step_max_id, newId);
+                                step = new Step(newId, getDelay(), getStoredColorId(), getDuration());
+                        }
+
+                        List<Integer> stepIds = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_scene_step_ids, sceneId);
+                        if (!stepIds.contains(step.getId())) {
+                                stepIds.add(step.getId());
+                                PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_scene_step_ids, sceneId, stepIds);
+                        }
+
+                        PreferenceUtil.setIndexedSharedPreferenceLong(R.string.key_scene_step_delay, step.getId(), step.getDelay());
+                        PreferenceUtil.setIndexedSharedPreferenceInt(R.string.key_scene_step_stored_color_id, step.getId(), step.getStoredColorId());
+                        PreferenceUtil.setIndexedSharedPreferenceLong(R.string.key_scene_step_duration, step.getId(), step.getDuration());
+                        return step;
+                }
+
+                /** Get the delay. */
+                public long getDelay() {
+                        return mDelay;
+                }
+
+                /** Get the stored color id. */
+                public int getStoredColorId() {
+                        return mStoredColorId;
+                }
+
+                /** Get the stored color. */
+                public StoredColor getStoredColor() {
+                        return ColorRegistry.getInstance().getStoredColor(getStoredColorId());
+                }
+
+                /** Get the duration. */
+                public long getDuration() {
+                        return mDuration;
+                }
+
+                /** Get the id for storage. */
+                public int getId() {
+                        return mId;
+                }
+
+                /** Update the duration. */
+                protected Step withDuration(final long duration) {
+                        return new Step(getId(), getDelay(), getStoredColorId(), duration);
+                }
+
+                /** Update the delay. */
+                protected Step withDelay(final long delay) {
+                        return new Step(getId(), delay, getStoredColorId(), getDuration());
+                }
+
+                @Override
+                public int compareTo(final Step other) {
+                        if (getDelay() == other.getDelay()) {
+                                if (getDuration() == other.getDuration()) {
+                                        return getStoredColor().getLight().getLabel().compareTo(other.getStoredColor().getLight().getLabel());
+                                }
+                                else {
+                                        return Long.compare(getDuration(), other.getDuration());
+                                }
+                        }
+                        else {
+                                return Long.compare(getDelay(), other.getDelay());
+                        }
+                }
+
+                @Override
+                public boolean equals(final Object obj) {
+                        if (!(obj instanceof Step)) {
+                                return false;
+                        }
+                        Step other = (Step) obj;
+                        return mDelay == other.mDelay && mDuration == other.mDuration && mId == other.mId && mStoredColorId == other.mStoredColorId;
+                }
+
+                @Override
+                public int hashCode() {
+                        final int prime = 31;
+                        int result = 1;
+                        result = prime * result + (int) (mDelay ^ (mDelay >>> 32));
+                        result = prime * result + (int) (mDuration ^ (mDuration >>> 32));
+                        result = prime * result + mId;
+                        result = prime * result + mStoredColorId;
+                        return result;
+                }
+
+                @NonNull
+                @Override
+                public String toString() {
+                        return "[" + getId() + "](" + getDelay() + ")(" + getStoredColor() + ")(" + getDuration() + ")";
+                }
+        }
+
+        /**
+         * Helper class combining light and steps.
+         */
+        public static class LightSteps {
+                /** The light. */
+                private final Light mLight;
+                /** The steps. */
+                private final List<Step> mSteps;
+
+                /**
+                 * Constructor.
+                 *
+                 * @param light The light
+                 * @param steps The steps
+                 */
+                public LightSteps(final Light light, final List<Step> steps) {
+                        mLight = light;
+                        mSteps = steps;
+                }
+
+                /** Get the light. */
+                public Light getLight() {
+                        return mLight;
+                }
+
+                /** Get the steps. */
+                public List<Step> getSteps() {
+                        return mSteps;
+                }
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneConfigurationFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneConfigurationFragment.java
@@ -1,0 +1,121 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ExpandableListView;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.alarms.LifxAlarmService;
+import de.jeisfeld.lifx.app.alarms.SelectDeviceDialogFragment;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.storedcolors.ColorRegistry;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoreColorType;
+import de.jeisfeld.lifx.app.util.DialogUtil;
+import de.jeisfeld.lifx.app.util.DialogUtil.RequestInputDialogFragment.RequestInputDialogListener;
+import de.jeisfeld.lifx.lan.Light;
+
+/** Fragment for configuration of a scene. */
+public class SceneConfigurationFragment extends Fragment {
+        /** Parameter key. */
+        private static final String PARAM_SCENE_ID = "sceneId";
+        /** Default duration. */
+        protected static final long DEFAULT_DURATION = 10000;
+
+        private Scene mScene;
+        private SceneStepExpandableListAdapter mAdapter;
+        private Map<Light, Boolean> mInitialExpandingStatus = new HashMap<>();
+
+        /** Navigate to this fragment. */
+        public static void navigate(final Fragment fragment, final Integer sceneId) {
+                FragmentActivity activity = fragment == null ? null : fragment.getActivity();
+                if (activity != null) {
+                        NavController navController = Navigation.findNavController(activity, R.id.nav_host_fragment);
+                        Bundle bundle = new Bundle();
+                        if (sceneId != null) {
+                                bundle.putInt(PARAM_SCENE_ID, sceneId);
+                        }
+                        navController.navigate(R.id.nav_scene_configuration, bundle);
+                }
+        }
+
+        @Override
+        public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+                View root = inflater.inflate(R.layout.fragment_scene_configuration, container, false);
+                final ExpandableListView listViewSceneSteps = root.findViewById(R.id.listViewSceneSteps);
+
+                final int sceneId = getArguments() == null ? -1 : getArguments().getInt(PARAM_SCENE_ID, -1);
+                mScene = fillFromSceneId(root, mScene == null ? sceneId : mScene.getId());
+
+                for (Scene.LightSteps lightSteps : mScene.getLightSteps()) {
+                        mInitialExpandingStatus.putIfAbsent(lightSteps.getLight(), true);
+                }
+                mAdapter = new SceneStepExpandableListAdapter(this, mScene, mInitialExpandingStatus);
+                listViewSceneSteps.setAdapter(mAdapter);
+                mInitialExpandingStatus = new HashMap<>();
+
+                root.findViewById(R.id.imageViewAddSceneLight).setOnClickListener(v -> {
+                        List<Light> lightsWithStoredColors = ColorRegistry.getInstance().getLightsWithStoredColors();
+                        lightsWithStoredColors.removeAll(mScene.getLightSteps().stream().map(Scene.LightSteps::getLight).collect(java.util.stream.Collectors.toSet()));
+                        SelectDeviceDialogFragment.displaySelectDeviceDialog(requireActivity(), device ->
+                                        StoredColorsDialogFragment.displayStoredColorsDialog(requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                                        (dialog, storedColor) -> {
+                                                                mScene.getSteps().add(new Scene.Step(0, storedColor.getId(), DEFAULT_DURATION));
+                                                                mScene = SceneRegistry.getInstance().addOrUpdate(mScene);
+                                                                mAdapter.notifyDataSetChanged(mScene);
+                                                        }), new ArrayList<>(lightsWithStoredColors));
+                });
+
+                root.findViewById(R.id.imageViewTestScene).setOnClickListener(v ->
+                        LifxAlarmService.triggerAlarmService(getContext(), LifxAlarmService.ACTION_TEST_SCENE, mScene.getId(), new Date()));
+
+                root.findViewById(R.id.imageViewDeleteScene).setOnClickListener(v -> DialogUtil.displayConfirmationMessage(requireActivity(), dialog -> {
+                        SceneRegistry.getInstance().remove(mScene);
+                        NavController navController = Navigation.findNavController(requireActivity(), R.id.nav_host_fragment);
+                        navController.navigateUp();
+                }, null, R.string.button_cancel, R.string.button_delete, R.string.message_confirm_delete_scene, mScene.getName()));
+
+                return root;
+        }
+
+        private Scene fillFromSceneId(final View root, final int sceneId) {
+                Scene scene = SceneRegistry.getInstance().getScene(sceneId);
+                final TextView textViewSceneName = root.findViewById(R.id.textViewSceneName);
+                textViewSceneName.setText(scene.getName());
+                textViewSceneName.setOnClickListener(v -> DialogUtil.displayInputDialog(requireActivity(), new RequestInputDialogListener() {
+                        @Override
+                        public void onDialogPositiveClick(final DialogFragment dialog, final String text) {
+                                if (text == null || text.trim().isEmpty()) {
+                                        DialogUtil.displayConfirmationMessage(requireActivity(), R.string.title_did_not_save_empty_name, R.string.message_did_not_save_empty_name);
+                                }
+                                else {
+                                        textViewSceneName.setText(text.trim());
+                                        mScene = mScene.withChangedName(getContext(), text.trim());
+                                        mAdapter.notifyDataSetChanged(mScene);
+                                }
+                        }
+
+                        @Override
+                        public void onDialogNegativeClick(final DialogFragment dialog) {
+                                // do nothing
+                        }
+                }, R.string.title_dialog_change_scene_name, R.string.button_rename, scene.getName(), R.string.message_dialog_new_scene_name));
+                return scene;
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneRegistry.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneRegistry.java
@@ -1,0 +1,142 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.content.Context;
+import android.util.SparseArray;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.util.PreferenceUtil;
+
+/**
+ * Registry holding information about scenes.
+ */
+public final class SceneRegistry {
+        /** Singleton instance. */
+        private static SceneRegistry mInstance = null;
+        /** The scenes. */
+        private final SparseArray<Scene> mScenes = new SparseArray<>();
+
+        /**
+         * Create the registry and retrieve stored entries.
+         */
+        private SceneRegistry() {
+                List<Integer> sceneIds = PreferenceUtil.getSharedPreferenceIntList(R.string.key_scene_ids);
+                for (int sceneId : sceneIds) {
+                        mScenes.put(sceneId, new Scene(sceneId));
+                }
+        }
+
+        /**
+         * Get the singleton instance.
+         *
+         * @return The instance
+         */
+        public static SceneRegistry getInstance() {
+                if (mInstance == null) {
+                        mInstance = new SceneRegistry();
+                }
+                return mInstance;
+        }
+
+        /**
+         * Get list of scenes.
+         *
+         * @return The list of scenes
+         */
+        public List<Scene> getScenes() {
+                List<Scene> result = new ArrayList<>();
+                for (int sceneId : PreferenceUtil.getSharedPreferenceIntList(R.string.key_scene_ids)) {
+                        Scene scene = mScenes.get(sceneId);
+                        if (scene != null) {
+                                result.add(scene);
+                        }
+                }
+                return result;
+        }
+
+        /**
+         * Get a single scene.
+         *
+         * @param id The id
+         * @return The scene
+         */
+        public Scene getScene(final int id) {
+                Scene scene = mScenes.get(id);
+                if (scene == null) {
+                        scene = new Scene(id);
+                        mScenes.put(id, scene);
+                }
+                return scene;
+        }
+
+        /**
+         * Get a new automatic scene name.
+         *
+         * @param context The context
+         * @return The scene name
+         */
+        public String getNewSceneName(final Context context) {
+                List<String> existingNames = getScenes().stream().map(Scene::getName).collect(Collectors.toList());
+                String name = null;
+                int count = 1;
+                while (name == null) {
+                        name = context.getResources().getString(R.string.default_scene_name, count);
+                        if (existingNames.contains(name)) {
+                                name = null;
+                                count++;
+                        }
+                }
+                return name;
+        }
+
+        /**
+         * Add or update a scene in local store.
+         *
+         * @param scene The scene
+         * @return The stored scene
+         */
+        protected Scene addOrUpdate(final Scene scene) {
+                Scene newScene = scene.store();
+                mScenes.put(newScene.getId(), newScene);
+                return newScene;
+        }
+
+        /**
+         * Remove a scene.
+         *
+         * @param scene The scene
+         */
+        protected void remove(final Scene scene) {
+                int sceneId = scene.getId();
+                mScenes.remove(sceneId);
+                List<Integer> sceneIds = PreferenceUtil.getSharedPreferenceIntList(R.string.key_scene_ids);
+                sceneIds.remove((Integer) sceneId);
+                PreferenceUtil.setSharedPreferenceIntList(R.string.key_scene_ids, sceneIds);
+
+                for (Scene.Step step : scene.getSteps()) {
+                        remove(step, sceneId);
+                }
+                PreferenceUtil.removeIndexedSharedPreference(R.string.key_scene_name, sceneId);
+        }
+
+        /**
+         * Remove a scene step.
+         *
+         * @param step    The step
+         * @param sceneId The scene id
+         */
+        protected void remove(final Scene.Step step, final int sceneId) {
+                int stepId = step.getId();
+                List<Integer> stepIds = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_scene_step_ids, sceneId);
+                stepIds.remove((Integer) stepId);
+                PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_scene_step_ids, sceneId, stepIds);
+
+                PreferenceUtil.removeIndexedSharedPreference(R.string.key_scene_step_delay, stepId);
+                PreferenceUtil.removeIndexedSharedPreference(R.string.key_scene_step_stored_color_id, stepId);
+                PreferenceUtil.removeIndexedSharedPreference(R.string.key_scene_step_duration, stepId);
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneStepExpandableListAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/SceneStepExpandableListAdapter.java
@@ -1,0 +1,275 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.content.Context;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.BaseExpandableListAdapter;
+import android.widget.ExpandableListView;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.lang.ref.WeakReference;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import androidx.navigation.NavController;
+import androidx.navigation.Navigation;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.scenes.Scene.LightSteps;
+import de.jeisfeld.lifx.app.scenes.Scene.Step;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.storedcolors.StoredColor;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoreColorType;
+import de.jeisfeld.lifx.app.util.DialogUtil;
+import de.jeisfeld.lifx.app.util.DialogUtil.RequestDurationDialogFragment.RequestDurationDialogListener;
+import de.jeisfeld.lifx.lan.Light;
+
+/** Adapter for the expandable list of scene steps. */
+public class SceneStepExpandableListAdapter extends BaseExpandableListAdapter {
+        private final SceneConfigurationFragment mFragment;
+        private Scene mScene;
+        private List<LightSteps> mLightStepsList;
+        private Map<Light, Boolean> mInitialExpandingStatus;
+        private WeakReference<ExpandableListView> mParent = new WeakReference<>(null);
+        private static final int SECONDS_PER_MINUTE = (int) TimeUnit.MINUTES.toSeconds(1);
+
+        protected SceneStepExpandableListAdapter(final SceneConfigurationFragment fragment, final Scene scene,
+                        final Map<Light, Boolean> initialExpandingStatus) {
+                mFragment = fragment;
+                mScene = scene;
+                mLightStepsList = scene.getLightSteps();
+                mInitialExpandingStatus = initialExpandingStatus;
+        }
+
+        protected Map<Light, Boolean> getExpandingStatus() {
+                ExpandableListView parent = mParent.get();
+                Map<Light, Boolean> result = new HashMap<>();
+                if (parent != null) {
+                        for (int groupPosition = 0; groupPosition < getGroupCount(); groupPosition++) {
+                                LightSteps lightSteps = getGroup(groupPosition);
+                                result.put(lightSteps.getLight(), parent.isGroupExpanded(groupPosition));
+                        }
+                }
+                return result;
+        }
+
+        @Override
+        public int getGroupCount() {
+                return mLightStepsList.size();
+        }
+
+        @Override
+        public int getChildrenCount(final int groupPosition) {
+                return getGroup(groupPosition).getSteps().size();
+        }
+
+        @Override
+        public LightSteps getGroup(final int groupPosition) {
+                return mLightStepsList.get(groupPosition);
+        }
+
+        @Override
+        public Step getChild(final int groupPosition, final int childPosition) {
+                return getGroup(groupPosition).getSteps().get(childPosition);
+        }
+
+        @Override
+        public long getGroupId(final int groupPosition) {
+                return groupPosition;
+        }
+
+        @Override
+        public long getChildId(final int groupPosition, final int childPosition) {
+                return childPosition;
+        }
+
+        @Override
+        public boolean hasStableIds() {
+                return false;
+        }
+
+        @Override
+        public View getGroupView(final int groupPosition, final boolean isExpanded, final View convertView, final ViewGroup parent) {
+                mParent = new WeakReference<>((ExpandableListView) parent);
+                View view = convertView;
+                if (convertView == null) {
+                        LayoutInflater layoutInflater = (LayoutInflater) mFragment.requireActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                        assert layoutInflater != null;
+                        view = layoutInflater.inflate(R.layout.list_view_scene_lights, parent, false);
+                }
+                if (groupPosition >= getGroupCount()) {
+                        return view;
+                }
+
+                LightSteps lightSteps = getGroup(groupPosition);
+                TextView listTitleTextView = view.findViewById(R.id.textViewDeviceName);
+                listTitleTextView.setText(lightSteps.getLight().getLabel());
+
+                boolean isCollapsed = !isExpanded;
+
+                Boolean initialExpandingStatus = mInitialExpandingStatus.get(lightSteps.getLight());
+                if (initialExpandingStatus != null) {
+                        if (initialExpandingStatus) {
+                                ((ExpandableListView) parent).expandGroup(groupPosition);
+                                isCollapsed = false;
+                        }
+                        else {
+                                ((ExpandableListView) parent).collapseGroup(groupPosition);
+                                isCollapsed = true;
+                        }
+                        mInitialExpandingStatus.remove(lightSteps.getLight());
+                }
+
+                TextView textViewStartTime = view.findViewById(R.id.textViewStartTime);
+                TextView textViewEndTime = view.findViewById(R.id.textViewEndTime);
+                ImageView imageViewAddStep = view.findViewById(R.id.imageViewAddSceneStep);
+
+                long minDelay = Long.MAX_VALUE;
+                long maxEndTime = Long.MIN_VALUE;
+                for (Step step : lightSteps.getSteps()) {
+                        minDelay = Math.min(minDelay, step.getDelay());
+                        maxEndTime = Math.max(maxEndTime, step.getDelay() + step.getDuration());
+                }
+
+                if (isCollapsed) {
+                        textViewStartTime.setText(getDelayString(minDelay));
+                        textViewStartTime.setVisibility(View.VISIBLE);
+                        textViewEndTime.setText(getDelayString(maxEndTime));
+                        textViewEndTime.setVisibility(View.VISIBLE);
+                        imageViewAddStep.setVisibility(View.GONE);
+                }
+                else {
+                        textViewStartTime.setVisibility(View.GONE);
+                        textViewEndTime.setVisibility(View.GONE);
+                        imageViewAddStep.setVisibility(View.VISIBLE);
+                        imageViewAddStep.setOnClickListener(v -> StoredColorsDialogFragment.displayStoredColorsDialog(mFragment.requireActivity(), (int) lightSteps.getLight().getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                        (dialog, storedColor) -> {
+                                                mScene.getSteps().add(new Step(maxEndTime, storedColor.getId(), SceneConfigurationFragment.DEFAULT_DURATION));
+                                                mScene = SceneRegistry.getInstance().addOrUpdate(mScene);
+                                                mInitialExpandingStatus = getExpandingStatus();
+                                                notifyDataSetChanged(mScene);
+                                        }));
+                }
+
+                return view;
+        }
+
+        @Override
+        public View getChildView(final int groupPosition, final int childPosition, final boolean isLastChild, final View convertView,
+                                final ViewGroup parent) {
+                final Step originalStep = getChild(groupPosition, childPosition);
+                View view = convertView;
+                if (convertView == null) {
+                        LayoutInflater layoutInflater = (LayoutInflater) mFragment.requireActivity().getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+                        assert layoutInflater != null;
+                        view = layoutInflater.inflate(R.layout.list_view_alarm_steps, parent, false);
+                }
+
+                final TextView textViewStartTime = view.findViewById(R.id.textViewStartTime);
+                final TextView textViewEndTime = view.findViewById(R.id.textViewEndTime);
+                textViewStartTime.setText(getDelayString(originalStep.getDelay()));
+                textViewEndTime.setText(getDelayString(originalStep.getDelay() + originalStep.getDuration()));
+
+                final ImageView imageViewStoredColor = view.findViewById(R.id.imageViewStoredColor);
+                final TextView textViewStoredColorName = view.findViewById(R.id.textViewStoredColorName);
+                imageViewStoredColor.setImageDrawable(originalStep.getStoredColor().getButtonDrawable(mFragment.requireContext()));
+                textViewStoredColorName.setText(originalStep.getStoredColor().getName());
+
+                View.OnClickListener changeColorListener = v -> {
+                        final Step step = getChild(groupPosition, childPosition);
+                        StoredColorsDialogFragment.displayStoredColorsDialog(mFragment.requireActivity(), step.getStoredColor().getDeviceId(), StoreColorType.ONLYSELECT, true, false,
+                                        (dialog, storedColor) -> {
+                                                Step newStep = new Step(step.getId(), step.getDelay(), storedColor.getId(), step.getDuration());
+                                                mScene.getSteps().remove(step);
+                                                mScene.getSteps().add(newStep);
+                                                SceneRegistry.getInstance().addOrUpdate(mScene);
+                                                notifyDataSetChanged();
+                                        });
+                };
+                imageViewStoredColor.setOnClickListener(changeColorListener);
+                textViewStoredColorName.setOnClickListener(changeColorListener);
+
+                textViewStartTime.setOnClickListener(v -> {
+                        final Step step = getChild(groupPosition, childPosition);
+                        int delaySeconds = (int) (step.getDelay() / TimeUnit.SECONDS.toMillis(1));
+
+                        DialogUtil.displayDurationDialog(mFragment.requireActivity(), new RequestDurationDialogListener() {
+                                @Override
+                                public void onDialogPositiveClick(final DialogFragment dialog, final int minutes, final int seconds) {
+                                        Step newStep = step.withDelay(TimeUnit.MINUTES.toMillis(minutes) + TimeUnit.SECONDS.toMillis(seconds));
+                                        mScene.updateDelay(newStep);
+                                        SceneRegistry.getInstance().addOrUpdate(mScene);
+                                        notifyDataSetChanged();
+                                }
+
+                                @Override
+                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                }
+                        }, R.string.title_dialog_scene_step_delay, R.string.button_ok, delaySeconds / SECONDS_PER_MINUTE,
+                                delaySeconds % SECONDS_PER_MINUTE, R.string.message_dialog_scene_step_delay);
+                });
+
+                textViewEndTime.setOnClickListener(v -> {
+                        final Step step = getChild(groupPosition, childPosition);
+                        int durationSeconds = (int) (step.getDuration() / TimeUnit.SECONDS.toMillis(1));
+
+                        DialogUtil.displayDurationDialog(mFragment.requireActivity(), new RequestDurationDialogListener() {
+                                @Override
+                                public void onDialogPositiveClick(final DialogFragment dialog, final int minutes, final int seconds) {
+                                        Step newStep = step.withDuration(TimeUnit.MINUTES.toMillis(minutes) + TimeUnit.SECONDS.toMillis(seconds));
+                                        mScene.updateDuration(newStep);
+                                        SceneRegistry.getInstance().addOrUpdate(mScene);
+                                        notifyDataSetChanged();
+                                }
+
+                                @Override
+                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                }
+                        }, R.string.title_dialog_scene_step_duration, R.string.button_ok, durationSeconds / SECONDS_PER_MINUTE,
+                                durationSeconds % SECONDS_PER_MINUTE, R.string.message_dialog_scene_step_duration);
+                });
+
+                view.findViewById(R.id.imageViewDelete).setOnClickListener(v -> DialogUtil.displayConfirmationMessage(mFragment.requireActivity(), dialog -> {
+                        mScene.updateDuration(originalStep.withDuration(0));
+                        mScene.removeStep(originalStep.getId());
+                        SceneRegistry.getInstance().remove(originalStep, mScene.getId());
+                        SceneRegistry.getInstance().addOrUpdate(mScene);
+                        mInitialExpandingStatus = getExpandingStatus();
+                        notifyDataSetChanged();
+
+                        if (mScene.getSteps().isEmpty()) {
+                                SceneRegistry.getInstance().remove(mScene);
+                                FragmentActivity activity = mFragment.requireActivity();
+                                NavController navController = Navigation.findNavController(activity, R.id.nav_host_fragment);
+                                navController.navigateUp();
+                        }
+                }, null, R.string.button_cancel, R.string.button_delete, R.string.message_confirm_delete_scene_step));
+
+                return view;
+        }
+
+        @Override
+        public boolean isChildSelectable(final int groupPosition, final int childPosition) {
+                return false;
+        }
+
+        protected void notifyDataSetChanged(final Scene scene) {
+                mScene = scene;
+                mLightStepsList = scene.getLightSteps();
+                super.notifyDataSetChanged();
+        }
+
+        protected static String getDelayString(final long delay) {
+                return delay == 3600000 ? "60:00" : String.format(Locale.getDefault(), "%1$tM:%1$tS", new Date(delay));
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesFragment.java
@@ -1,0 +1,66 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.os.Bundle;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.alarms.SelectDeviceDialogFragment;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.storedcolors.ColorRegistry;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment;
+import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoreColorType;
+import de.jeisfeld.lifx.app.util.DialogUtil;
+import de.jeisfeld.lifx.lan.Light;
+
+/**
+ * Fragment for management of scenes.
+ */
+public class ScenesFragment extends Fragment {
+        @Override
+        public View onCreateView(final LayoutInflater inflater, final ViewGroup container, final Bundle savedInstanceState) {
+                View root = inflater.inflate(R.layout.fragment_scenes, container, false);
+                final RecyclerView recyclerView = root.findViewById(R.id.recyclerViewScenes);
+                populateRecyclerView(recyclerView);
+
+                root.findViewById(R.id.buttonAddScene).setOnClickListener(v -> createNewScene());
+
+                return root;
+        }
+
+        /** Populate the recycler view. */
+        private void populateRecyclerView(final RecyclerView recyclerView) {
+                ScenesViewAdapter adapter = new ScenesViewAdapter(this, recyclerView);
+                ItemTouchHelper.Callback callback = new ScenesItemMoveCallback(adapter);
+                ItemTouchHelper touchHelper = new ItemTouchHelper(callback);
+                adapter.setStartDragListener(touchHelper::startDrag);
+                touchHelper.attachToRecyclerView(recyclerView);
+                recyclerView.setAdapter(adapter);
+        }
+
+        private void createNewScene() {
+                if (ColorRegistry.getInstance().getLightsWithStoredColors().isEmpty()) {
+                        DialogUtil.displayConfirmationMessage(requireActivity(), R.string.title_no_stored_colors, R.string.message_no_stored_colors);
+                        return;
+                }
+
+                List<Light> lightsWithStoredColors = ColorRegistry.getInstance().getLightsWithStoredColors();
+                SelectDeviceDialogFragment.displaySelectDeviceDialog(requireActivity(), device ->
+                                StoredColorsDialogFragment.displayStoredColorsDialog(requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                                (dialog, storedColor) -> {
+                                                        List<Scene.Step> steps = new ArrayList<>();
+                                                        steps.add(new Scene.Step(0, storedColor.getId(), SceneConfigurationFragment.DEFAULT_DURATION));
+                                                        Scene scene = new Scene(SceneRegistry.getInstance().getNewSceneName(getContext()), steps);
+                                                        scene = SceneRegistry.getInstance().addOrUpdate(scene);
+                                                        SceneConfigurationFragment.navigate(ScenesFragment.this, scene.getId());
+                                                }), new ArrayList<>(lightsWithStoredColors));
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesItemMoveCallback.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesItemMoveCallback.java
@@ -1,0 +1,76 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import javax.annotation.Nonnull;
+
+import androidx.recyclerview.widget.ItemTouchHelper;
+import androidx.recyclerview.widget.RecyclerView;
+
+/**
+ * Callback for handling drag of scenes.
+ */
+public class ScenesItemMoveCallback extends ItemTouchHelper.Callback {
+        /** The adapter. */
+        private final ItemTouchHelperContract mAdapter;
+
+        /** Constructor.
+         * @param adapter The adapter.
+         */
+        public ScenesItemMoveCallback(final ItemTouchHelperContract adapter) {
+                mAdapter = adapter;
+        }
+
+        @Override
+        public boolean isLongPressDragEnabled() {
+                return false;
+        }
+
+        @Override
+        public boolean isItemViewSwipeEnabled() {
+                return false;
+        }
+
+        @Override
+        public void onSwiped(@Nonnull final RecyclerView.ViewHolder viewHolder, final int direction) {
+        }
+
+        @Override
+        public int getMovementFlags(@Nonnull final RecyclerView recyclerView, @Nonnull final RecyclerView.ViewHolder viewHolder) {
+                int dragFlags = ItemTouchHelper.UP | ItemTouchHelper.DOWN;
+                return makeMovementFlags(dragFlags, 0);
+        }
+
+        @Override
+        public boolean onMove(@Nonnull final RecyclerView recyclerView, final RecyclerView.ViewHolder viewHolder,
+                                final RecyclerView.ViewHolder target) {
+                mAdapter.onRowMoved(viewHolder.getAdapterPosition(), target.getAdapterPosition());
+                return true;
+        }
+
+        @Override
+        public void onSelectedChanged(final RecyclerView.ViewHolder viewHolder, final int actionState) {
+                if (actionState != ItemTouchHelper.ACTION_STATE_IDLE) {
+                        if (viewHolder instanceof ScenesViewAdapter.MyViewHolder) {
+                                ScenesViewAdapter.MyViewHolder myViewHolder = (ScenesViewAdapter.MyViewHolder) viewHolder;
+                                mAdapter.onRowSelected(myViewHolder);
+                        }
+                }
+                super.onSelectedChanged(viewHolder, actionState);
+        }
+
+        @Override
+        public void clearView(@Nonnull final RecyclerView recyclerView, @Nonnull final RecyclerView.ViewHolder viewHolder) {
+                super.clearView(recyclerView, viewHolder);
+                if (viewHolder instanceof ScenesViewAdapter.MyViewHolder) {
+                        ScenesViewAdapter.MyViewHolder myViewHolder = (ScenesViewAdapter.MyViewHolder) viewHolder;
+                        mAdapter.onRowClear(myViewHolder);
+                }
+        }
+
+        /** Callback for row actions. */
+        public interface ItemTouchHelperContract {
+                void onRowMoved(int fromPosition, int toPosition);
+                void onRowSelected(ScenesViewAdapter.MyViewHolder myViewHolder);
+                void onRowClear(ScenesViewAdapter.MyViewHolder myViewHolder);
+        }
+}
+

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesViewAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesViewAdapter.java
@@ -1,0 +1,128 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.lang.ref.WeakReference;
+import java.util.Collections;
+import java.util.List;
+
+import androidx.fragment.app.Fragment;
+import androidx.recyclerview.widget.RecyclerView;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.util.DialogUtil;
+import de.jeisfeld.lifx.app.util.PreferenceUtil;
+
+/** Adapter for scenes list. */
+public class ScenesViewAdapter extends RecyclerView.Adapter<ScenesViewAdapter.MyViewHolder>
+        implements ScenesItemMoveCallback.ItemTouchHelperContract {
+
+        private final List<Scene> mScenes;
+        private final List<Integer> mSceneIds;
+        private final WeakReference<Fragment> mFragment;
+        private StartDragListener mStartDragListener;
+
+        /** Listener to start drag. */
+        public interface StartDragListener {
+                void requestDrag(RecyclerView.ViewHolder viewHolder);
+        }
+
+        /** Constructor. */
+        public ScenesViewAdapter(final Fragment fragment, final RecyclerView recyclerView) {
+                mScenes = SceneRegistry.getInstance().getScenes();
+                mSceneIds = PreferenceUtil.getSharedPreferenceIntList(R.string.key_scene_ids);
+                mFragment = new WeakReference<>(fragment);
+                setHasStableIds(true);
+        }
+
+        /** Set drag listener. */
+        public void setStartDragListener(final StartDragListener startDragListener) {
+                mStartDragListener = startDragListener;
+        }
+
+        @Override
+        public MyViewHolder onCreateViewHolder(final ViewGroup parent, final int viewType) {
+                View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.list_view_scenes, parent, false);
+                return new MyViewHolder(view);
+        }
+
+        @Override
+        public void onBindViewHolder(final MyViewHolder holder, final int position) {
+                holder.mScene = mScenes.get(position);
+                holder.mTextViewSceneName.setText(holder.mScene.getName());
+                holder.mTextViewSceneName.setOnClickListener(v -> SceneConfigurationFragment.navigate(mFragment.get(), holder.mScene.getId()));
+
+                holder.mImageViewDelete.setOnClickListener(v -> DialogUtil.displayConfirmationMessage(mFragment.get().requireActivity(), dialog -> {
+                        SceneRegistry.getInstance().remove(holder.mScene);
+                        int pos = holder.getAdapterPosition();
+                        mScenes.remove(pos);
+                        mSceneIds.remove(pos);
+                        notifyItemRemoved(pos);
+                        notifyItemRangeChanged(pos, mScenes.size() - pos);
+                }, null, R.string.button_cancel, R.string.button_delete, R.string.message_confirm_delete_scene, holder.mScene.getName()));
+
+                holder.mImageViewDragHandle.setOnTouchListener((v, event) -> {
+                        if (mStartDragListener != null) {
+                                mStartDragListener.requestDrag(holder);
+                        }
+                        return false;
+                });
+        }
+
+        @Override
+        public int getItemCount() {
+                return mScenes.size();
+        }
+
+        @Override
+        public long getItemId(final int position) {
+                return mScenes.get(position).getId();
+        }
+
+        @Override
+        public void onRowMoved(final int fromPosition, final int toPosition) {
+                if (fromPosition < toPosition) {
+                        for (int i = fromPosition; i < toPosition; i++) {
+                                Collections.swap(mScenes, i, i + 1);
+                                Collections.swap(mSceneIds, i, i + 1);
+                        }
+                }
+                else {
+                        for (int i = fromPosition; i > toPosition; i--) {
+                                Collections.swap(mScenes, i, i - 1);
+                                Collections.swap(mSceneIds, i, i - 1);
+                        }
+                }
+                notifyItemMoved(fromPosition, toPosition);
+                PreferenceUtil.setSharedPreferenceIntList(R.string.key_scene_ids, mSceneIds);
+        }
+
+        @Override
+        public void onRowSelected(final MyViewHolder myViewHolder) {
+                // do nothing
+        }
+
+        @Override
+        public void onRowClear(final MyViewHolder myViewHolder) {
+                // do nothing
+        }
+
+        /** View holder. */
+        public static class MyViewHolder extends RecyclerView.ViewHolder {
+                private Scene mScene;
+                private final TextView mTextViewSceneName;
+                private final ImageView mImageViewDelete;
+                private final ImageView mImageViewDragHandle;
+
+                MyViewHolder(final View view) {
+                        super(view);
+                        mTextViewSceneName = view.findViewById(R.id.textViewSceneName);
+                        mImageViewDelete = view.findViewById(R.id.imageViewDelete);
+                        mImageViewDragHandle = view.findViewById(R.id.imageViewDragHandle);
+                }
+        }
+}
+

--- a/LifxTools/app/src/main/res/layout/fragment_scene_configuration.xml
+++ b/LifxTools/app/src/main/res/layout/fragment_scene_configuration.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/activity_margin"
+    android:paddingHorizontal="@dimen/activity_margin">
+
+    <TextView
+        android:id="@+id/textViewSceneName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ExpandableListView
+        android:id="@+id/listViewSceneSteps"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:layout_marginBottom="@dimen/medium_margin"
+        app:layout_constraintBottom_toTopOf="@id/imageViewAddSceneLight"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/textViewSceneName"
+        app:layout_constraintVertical_bias="0" />
+
+    <ImageView
+        android:id="@+id/imageViewAddSceneLight"
+        android:layout_width="@dimen/medium_button_size"
+        android:layout_height="@dimen/medium_button_size"
+        android:src="@drawable/ic_button_add"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/imageViewDeleteScene"
+        android:layout_width="@dimen/medium_button_size"
+        android:layout_height="@dimen/medium_button_size"
+        android:src="@drawable/ic_button_delete"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/imageViewTestScene"
+        app:layout_constraintStart_toEndOf="@id/imageViewAddSceneLight"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/imageViewTestScene"
+        android:layout_width="@dimen/medium_button_size"
+        android:layout_height="@dimen/medium_button_size"
+        android:src="@drawable/ic_button_play"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        tools:ignore="ContentDescription" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/fragment_scenes.xml
+++ b/LifxTools/app/src/main/res/layout/fragment_scenes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingTop="@dimen/activity_margin"
+    android:paddingHorizontal="@dimen/activity_margin">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewScenes"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_marginBottom="@dimen/medium_margin"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@id/buttonAddScene"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_bias="0" />
+
+    <Button
+        android:id="@+id/buttonAddScene"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/button_add_scene"
+        app:layout_constraintBottom_toBottomOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/list_view_scene_lights.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_scene_lights.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:paddingStart="?android:attr/expandableListPreferredItemPaddingLeft"
+    android:paddingTop="@dimen/list_vertical_margin"
+    android:paddingBottom="@dimen/list_vertical_margin"
+    tools:ignore="RtlSymmetry">
+
+    <TextView
+        android:id="@+id/textViewStartTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:visibility="gone"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+    <TextView
+        android:id="@+id/textViewEndTime"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:paddingStart="@dimen/list_horizontal_margin"
+        android:paddingEnd="@dimen/list_horizontal_margin"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        android:visibility="gone"
+        app:layout_constraintStart_toEndOf="@id/textViewStartTime"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+    <TextView
+        android:id="@+id/textViewDeviceName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        app:layout_constraintEnd_toStartOf="@id/imageViewAddSceneStep"
+        app:layout_constraintStart_toEndOf="@id/textViewEndTime"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription,RtlSymmetry" />
+
+    <ImageView
+        android:id="@+id/imageViewAddSceneStep"
+        android:layout_width="@dimen/small_button_size"
+        android:layout_height="@dimen/small_button_size"
+        android:src="@drawable/ic_button_add"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/list_view_scenes.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_scenes.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="horizontal"
+    android:paddingTop="@dimen/list_vertical_margin"
+    android:paddingBottom="@dimen/list_vertical_margin">
+
+    <TextView
+        android:id="@+id/textViewSceneName"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/list_horizontal_margin"
+        android:layout_marginEnd="@dimen/list_horizontal_margin"
+        android:textAppearance="?android:attr/textAppearanceMedium"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/imageViewDelete"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/imageViewDelete"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_marginEnd="@dimen/list_horizontal_margin"
+        android:src="@drawable/ic_button_delete"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toStartOf="@id/imageViewDragHandle"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+    <ImageView
+        android:id="@+id/imageViewDragHandle"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:src="@drawable/ic_drag_handle"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:ignore="ContentDescription" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/menu/activity_main_drawer.xml
+++ b/LifxTools/app/src/main/res/menu/activity_main_drawer.xml
@@ -11,6 +11,10 @@
             android:id="@+id/nav_alarms"
             android:icon="@drawable/ic_menu_alarms"
             android:title="@string/menu_alarms" />
+        <item
+            android:id="@+id/nav_scenes"
+            android:icon="@drawable/ic_menu_alarms"
+            android:title="@string/menu_scenes" />
 
         <item android:title="@string/menu_settings">
             <menu>

--- a/LifxTools/app/src/main/res/navigation/mobile_navigation.xml
+++ b/LifxTools/app/src/main/res/navigation/mobile_navigation.xml
@@ -30,10 +30,22 @@
         tools:layout="@layout/fragment_alarms" />
 
     <fragment
+        android:id="@+id/nav_scenes"
+        android:name="de.jeisfeld.lifx.app.scenes.ScenesFragment"
+        android:label="@string/menu_scenes"
+        tools:layout="@layout/fragment_scenes" />
+
+    <fragment
         android:id="@+id/nav_alarm_configuration"
         android:name="de.jeisfeld.lifx.app.alarms.AlarmConfigurationFragment"
         android:label="@string/menu_alarm_configuration"
         tools:layout="@layout/fragment_alarm_configuration" />
+
+    <fragment
+        android:id="@+id/nav_scene_configuration"
+        android:name="de.jeisfeld.lifx.app.scenes.SceneConfigurationFragment"
+        android:label="@string/menu_scene_configuration"
+        tools:layout="@layout/fragment_scene_configuration" />
 
     <fragment
         android:id="@+id/nav_settings"

--- a/LifxTools/app/src/main/res/values/strings.xml
+++ b/LifxTools/app/src/main/res/values/strings.xml
@@ -11,7 +11,9 @@
     <string name="menu_stored_colors">Stored colors</string>
     <string name="menu_manage_devices">Manage devices</string>
     <string name="menu_alarms">Alarms</string>
+    <string name="menu_scenes">Scenes</string>
     <string name="menu_alarm_configuration">Alarm Configuration</string>
+    <string name="menu_scene_configuration">Scene Configuration</string>
     <string name="menu_alarm_step_configuration">Alarm Step Configuration</string>
     <string name="menu_general_settings">General Settings</string>
     <string name="menu_settings">Settings</string>
@@ -21,6 +23,7 @@
 
     <string name="color_off">OFF</string>
     <string name="default_alarm_name">Alarm %1$d</string>
+    <string name="default_scene_name">Scene %1$d</string>
     <string name="alarm_stopsequence_name">%1$s (Stop Sequence)</string>
 
     <string name="notification_channel_animation">LIFX Animations</string>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -10,15 +10,21 @@
     <string name="title_dialog_alarm_time">Set Alarm Time</string>
     <string name="title_dialog_copy_alarm">Copy Alarm</string>
     <string name="title_dialog_change_alarm_name">Change Alarm Name</string>
+    <string name="title_dialog_change_scene_name">Change Scene Name</string>
     <string name="title_dialog_change_color_name">Change Color Name</string>
     <string name="title_dialog_select_date_for_import">Select date of settings for import</string>
     <string name="message_dialog_new_alarm_name">New Alarm Name:</string>
+    <string name="message_dialog_new_scene_name">New Scene Name:</string>
     <string name="message_dialog_new_color_name">New Color Name:</string>
 
     <string name="title_dialog_alarm_step_delay">Alarm step delay</string>
     <string name="message_dialog_alarm_step_delay">Set the delay of the alarm step after alarm start</string>
     <string name="title_dialog_alarm_step_duration">Alarm step duration</string>
     <string name="message_dialog_alarm_step_duration">Set the duration of the alarm step</string>
+    <string name="title_dialog_scene_step_delay">Scene step delay</string>
+    <string name="message_dialog_scene_step_delay">Set the delay of the scene step after start</string>
+    <string name="title_dialog_scene_step_duration">Scene step duration</string>
+    <string name="message_dialog_scene_step_duration">Set the duration of the scene step</string>
 
     <string name="title_no_stored_colors">No stored colors</string>
     <string name="message_no_stored_colors">There are no stored colors. You need to store colors before you can use them for alarms.</string>
@@ -60,6 +66,7 @@
     <string name="button_rename">Rename</string>
     <string name="button_copy">Create copy</string>
     <string name="button_add_alarm">Add alarm</string>
+    <string name="button_add_scene">Add scene</string>
     <string name="button_overwrite">Overwrite</string>
     <string name="button_import">Import</string>
 
@@ -132,6 +139,8 @@
     <string name="message_confirm_delete_alarm">Do you want to delete the alarm “%1$s” from the app?</string>
     <string name="message_confirm_delete_alarm_stopsequence">Do you want to delete the stop sequence of alarm “%1$s” from the app?</string>
     <string name="message_confirm_delete_alarm_step">Do you want to delete the alarm step?</string>
+    <string name="message_confirm_delete_scene">Do you want to delete the scene “%1$s” from the app?</string>
+    <string name="message_confirm_delete_scene_step">Do you want to delete the scene step?</string>
     <string name="message_no_device_with_stored_colors">No LIFX device with stored colors available.</string>
 
     <string name="toast_saved_color">Color “%1$s” was saved.</string>

--- a/LifxTools/app/src/main/res/values/strings_preferences.xml
+++ b/LifxTools/app/src/main/res/values/strings_preferences.xml
@@ -82,6 +82,16 @@
     <string name="key_alarm_step_ringtone_uri" translatable="false">alarm_step_ringtone_uri</string>
     <string name="key_alarm_step_ringtone_name" translatable="false">alarm_step_ringtone_name</string>
 
+    <!-- Keys for scenes -->
+    <string name="key_scene_ids" translatable="false">scene_ids</string>
+    <string name="key_scene_max_id" translatable="false">scene_max_id</string>
+    <string name="key_scene_step_max_id" translatable="false">scene_step_max_id</string>
+    <string name="key_scene_name" translatable="false">scene_name</string>
+    <string name="key_scene_step_ids" translatable="false">scene_step_ids</string>
+    <string name="key_scene_step_delay" translatable="false">scene_step_delay</string>
+    <string name="key_scene_step_stored_color_id" translatable="false">scene_step_stored_color_id</string>
+    <string name="key_scene_step_duration" translatable="false">scene_step_duration</string>
+
     <!-- Keys for statistics -->
     <string name="key_statistics_initialversion" translatable="false">statistics_initialversion</string>
     <string name="key_statistics_firststarttime" translatable="false">statistics_firststarttime</string>


### PR DESCRIPTION
## Summary
- introduce scenes, a configurable sequence of light actions
- add scenes list and configuration screens with testing capability
- wire scenes into navigation and storage

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bde98d3430832288522dc961c3ce94