### PR TITLE
Add scenes selection on home screen

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
@@ -94,15 +94,14 @@ public class HomeFragment extends ListFragment {
                 mScenesHeaderView = LayoutInflater.from(getContext()).inflate(R.layout.list_view_home_scene, getListView(), false);
                 Button buttonScenes = mScenesHeaderView.findViewById(R.id.buttonScenes);
                 buttonScenes.setOnClickListener(v -> ScenesDialogFragment.displayScenesDialog(requireActivity()));
-                getListView().addHeaderView(mScenesHeaderView, null, false);
 
                 if (DeviceRegistry.getInstance().getDevices(false).size() == 0) {
                         getListView().setVisibility(View.GONE);
                         requireView().findViewById(R.id.textViewNoDevice).setVisibility(View.VISIBLE);
                 }
                 mAdapter = new DeviceAdapter(this, new NoDeviceCallback());
-                setListAdapter(mAdapter);
                 updateScenesHeaderVisibility();
+                setListAdapter(mAdapter);
 
 		ConstraintLayout layoutColorPicker = requireView().findViewById(R.id.layoutColorPicker);
 		ConstraintLayout layoutBrightnessColorTempPicker = requireView().findViewById(R.id.layoutBrightnessColorTempPicker);
@@ -155,8 +154,18 @@ public class HomeFragment extends ListFragment {
          */
         private void updateScenesHeaderVisibility() {
                 if (mScenesHeaderView != null) {
-                        mScenesHeaderView.setVisibility(SceneRegistry.getInstance().getScenes().isEmpty()
-                                        ? View.GONE : View.VISIBLE);
+                        boolean hasScenes = !SceneRegistry.getInstance().getScenes().isEmpty();
+                        if (hasScenes) {
+                                if (mScenesHeaderView.getParent() == null) {
+                                        getListView().addHeaderView(mScenesHeaderView, null, false);
+                                        if (getListView().getAdapter() != null) {
+                                                setListAdapter(mAdapter);
+                                        }
+                                }
+                        }
+                        else if (mScenesHeaderView.getParent() != null) {
+                                getListView().removeHeaderView(mScenesHeaderView);
+                        }
                 }
         }
 

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
@@ -12,6 +12,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
+import android.widget.Button;
 
 import com.skydoves.colorpickerview.ColorPickerView;
 import com.skydoves.colorpickerview.listeners.ColorListener;
@@ -28,6 +29,8 @@ import androidx.fragment.app.ListFragment;
 import de.jeisfeld.lifx.app.Application;
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.scenes.SceneRegistry;
+import de.jeisfeld.lifx.app.scenes.ScenesDialogFragment;
 import de.jeisfeld.lifx.app.util.ColorUtil;
 import de.jeisfeld.lifx.app.util.ImageUtil;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
@@ -57,11 +60,15 @@ public class HomeFragment extends ListFragment {
 	/**
 	 * The adapter used.
 	 */
-	private DeviceAdapter mAdapter;
-	/**
-	 * The view creation time.
-	 */
-	private long mViewCreationTime;
+        private DeviceAdapter mAdapter;
+        /**
+         * The view creation time.
+         */
+        private long mViewCreationTime;
+        /**
+         * Header view for scenes selection.
+         */
+        private View mScenesHeaderView;
 
 	/**
 	 * Send broadcast to home fragment informing about the end of an animation.
@@ -81,15 +88,21 @@ public class HomeFragment extends ListFragment {
 	}
 
 	@Override
-	public final void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
-		super.onViewCreated(view, savedInstanceState);
+        public final void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
+                super.onViewCreated(view, savedInstanceState);
 
-		if (DeviceRegistry.getInstance().getDevices(false).size() == 0) {
-			getListView().setVisibility(View.GONE);
-			requireView().findViewById(R.id.textViewNoDevice).setVisibility(View.VISIBLE);
-		}
-		mAdapter = new DeviceAdapter(this, new NoDeviceCallback());
-		setListAdapter(mAdapter);
+                mScenesHeaderView = LayoutInflater.from(getContext()).inflate(R.layout.list_view_home_scene, getListView(), false);
+                Button buttonScenes = mScenesHeaderView.findViewById(R.id.buttonScenes);
+                buttonScenes.setOnClickListener(v -> ScenesDialogFragment.displayScenesDialog(requireActivity()));
+                getListView().addHeaderView(mScenesHeaderView, null, false);
+
+                if (DeviceRegistry.getInstance().getDevices(false).size() == 0) {
+                        getListView().setVisibility(View.GONE);
+                        requireView().findViewById(R.id.textViewNoDevice).setVisibility(View.VISIBLE);
+                }
+                mAdapter = new DeviceAdapter(this, new NoDeviceCallback());
+                setListAdapter(mAdapter);
+                updateScenesHeaderVisibility();
 
 		ConstraintLayout layoutColorPicker = requireView().findViewById(R.id.layoutColorPicker);
 		ConstraintLayout layoutBrightnessColorTempPicker = requireView().findViewById(R.id.layoutBrightnessColorTempPicker);
@@ -110,10 +123,12 @@ public class HomeFragment extends ListFragment {
 	}
 
 	@Override
-	public final void onResume() {
-		super.onResume();
+        public final void onResume() {
+                super.onResume();
 
-		ContextCompat.registerReceiver(requireActivity(), mReceiver, new IntentFilter(EXTRA_ANIMATION_STOP_INTENT), ContextCompat.RECEIVER_NOT_EXPORTED);
+                updateScenesHeaderVisibility();
+
+                ContextCompat.registerReceiver(requireActivity(), mReceiver, new IntentFilter(EXTRA_ANIMATION_STOP_INTENT), ContextCompat.RECEIVER_NOT_EXPORTED);
 
 		mExecutor = Executors.newScheduledThreadPool(1);
 		long refreshDelay = PreferenceUtil.getSharedPreferenceLongString(R.string.key_pref_refresh_period, R.string.pref_default_refresh_period);
@@ -127,13 +142,23 @@ public class HomeFragment extends ListFragment {
 	}
 
 	@Override
-	public final void onPause() {
-		super.onPause();
-		mExecutor.shutdown();
-		mExecutor = null;
+        public final void onPause() {
+                super.onPause();
+                mExecutor.shutdown();
+                mExecutor = null;
 
-		requireActivity().unregisterReceiver(mReceiver);
-	}
+                requireActivity().unregisterReceiver(mReceiver);
+        }
+
+        /**
+         * Update visibility of the scenes header depending on stored scenes.
+         */
+        private void updateScenesHeaderVisibility() {
+                if (mScenesHeaderView != null) {
+                        mScenesHeaderView.setVisibility(SceneRegistry.getInstance().getScenes().isEmpty()
+                                        ? View.GONE : View.VISIBLE);
+                }
+        }
 
 	/**
 	 * Prepare the color pickers shown in landscape view.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesDialogFragment.java
@@ -1,0 +1,66 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.GridView;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.Date;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.alarms.LifxAlarmService;
+
+/**
+ * Dialog for selecting and executing scenes.
+ */
+public class ScenesDialogFragment extends DialogFragment {
+        /**
+         * Show the scenes dialog.
+         *
+         * @param activity The current activity.
+         */
+        public static void displayScenesDialog(final FragmentActivity activity) {
+                ScenesDialogFragment fragment = new ScenesDialogFragment();
+                fragment.show(activity.getSupportFragmentManager(), fragment.getClass().toString());
+        }
+
+        @Override
+        @NonNull
+        public final Dialog onCreateDialog(final Bundle savedInstanceState) {
+                List<Scene> scenes = SceneRegistry.getInstance().getScenes();
+
+                View view = View.inflate(requireActivity(), R.layout.dialog_scenes, null);
+                GridView gridView = view.findViewById(R.id.gridViewScenes);
+                ArrayAdapter<Scene> adapter = new ArrayAdapter<Scene>(requireContext(), R.layout.grid_entry_scene, scenes) {
+                        @Override
+                        public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
+                                final View newView = convertView == null
+                                                ? View.inflate(requireActivity(), R.layout.grid_entry_scene, null)
+                                                : convertView;
+                                final Scene scene = scenes.get(position);
+                                ((TextView) newView.findViewById(R.id.textViewSceneName)).setText(scene.getName());
+                                ImageView imageView = newView.findViewById(R.id.imageViewRunScene);
+                                imageView.setOnClickListener(v -> {
+                                        LifxAlarmService.triggerAlarmService(requireContext(),
+                                                        LifxAlarmService.ACTION_TEST_SCENE, scene.getId(), new Date());
+                                        dismiss();
+                                });
+                                return newView;
+                        }
+                };
+                gridView.setAdapter(adapter);
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+                builder.setView(view);
+                return builder.create();
+        }
+}

--- a/LifxTools/app/src/main/res/layout/dialog_scenes.xml
+++ b/LifxTools/app/src/main/res/layout/dialog_scenes.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:paddingStart="?attr/dialogPreferredPadding"
+    android:paddingTop="?attr/dialogPreferredPadding"
+    android:paddingEnd="?attr/dialogPreferredPadding">
+
+    <TextView
+        android:id="@+id/dialog_title_select"
+        style="@android:style/TextAppearance.Material.DialogWindowTitle"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:text="@string/title_dialog_select_scene"
+        android:textAlignment="viewStart"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <GridView
+        android:id="@+id/gridViewScenes"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/medium_margin"
+        android:layout_marginBottom="?attr/dialogPreferredPadding"
+        android:numColumns="3"
+        app:layout_constrainedHeight="true"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/dialog_title_select" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/grid_entry_scene.xml
+++ b/LifxTools/app/src/main/res/layout/grid_entry_scene.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:layout_marginBottom="@dimen/small_margin"
+    android:orientation="vertical">
+
+    <ImageView
+        android:id="@+id/imageViewRunScene"
+        android:layout_width="@dimen/medium_button_size"
+        android:layout_height="@dimen/medium_button_size"
+        android:layout_gravity="center_vertical|center_horizontal"
+        android:contentDescription="run scene"
+        android:src="@drawable/ic_button_play" />
+
+    <TextView
+        android:id="@+id/textViewSceneName"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:layout_gravity="center_horizontal"
+        android:lines="2"
+        android:textAlignment="center"
+        android:textAppearance="?android:attr/textAppearanceSmall" />
+</LinearLayout>

--- a/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/listelement_light_height"
+    android:orientation="horizontal"
+    android:paddingTop="@dimen/list_vertical_margin"
+    android:paddingBottom="@dimen/list_vertical_margin">
+
+    <TextView
+        android:id="@+id/textViewScenes"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_marginStart="@dimen/list_horizontal_margin"
+        android:layout_weight="1"
+        android:gravity="center_vertical"
+        android:text="@string/menu_scenes"
+        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    <Button
+        android:id="@+id/buttonScenes"
+        android:layout_width="@dimen/medium_button_size"
+        android:layout_height="@dimen/medium_button_size"
+        android:layout_gravity="center_vertical|center_horizontal"
+        android:layout_marginEnd="@dimen/list_horizontal_margin"
+        android:background="@drawable/ic_menu_stored_colors" />
+</LinearLayout>

--- a/LifxTools/app/src/main/res/values-de/strings.xml
+++ b/LifxTools/app/src/main/res/values-de/strings.xml
@@ -11,7 +11,9 @@
     <string name="menu_stored_colors">Gespeicherte Farben</string>
     <string name="menu_manage_devices">Geräte verwalten</string>
     <string name="menu_alarms">Alarme</string>
+    <string name="menu_scenes">Szenen</string>
     <string name="menu_alarm_configuration">Alarmkonfiguration</string>
+    <string name="menu_scene_configuration">Szenenkonfiguration</string>
     <string name="menu_alarm_step_configuration">Alarmschrittkonfiguration</string>
     <string name="menu_general_settings">Allgemeine Einstellungen</string>
     <string name="menu_settings">Einstellungen</string>
@@ -21,6 +23,7 @@
 
     <string name="color_off">AUS</string>
     <string name="default_alarm_name">Alarm %1$d</string>
+    <string name="default_scene_name">Szene %1$d</string>
     <string name="alarm_stopsequence_name">%1$s (Stoppsequenz)</string>
 
     <string name="notification_channel_animation">LIFX-Animationen</string>

--- a/LifxTools/app/src/main/res/values-de/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-de/strings_dialog.xml
@@ -80,6 +80,17 @@
     <string name="label_alarm_step_end">Ende</string>
     <string name="hint_select_stored_color">(Gespeicherte Farbe wählen)</string>
 
+    <string name="title_dialog_select_scene">Szene auswählen</string>
+    <string name="title_dialog_change_scene_name">Szenennamen ändern</string>
+    <string name="message_dialog_new_scene_name">Neuer Szenenname:</string>
+    <string name="title_dialog_scene_step_delay">Verzögerung des Szenenschritts</string>
+    <string name="message_dialog_scene_step_delay">Legen Sie die Verzögerung des Szenenschritts nach dem Start fest</string>
+    <string name="title_dialog_scene_step_duration">Dauer des Szenenschritts</string>
+    <string name="message_dialog_scene_step_duration">Legen Sie die Dauer des Szenenschritts fest</string>
+    <string name="button_add_scene">Szene hinzufügen</string>
+    <string name="message_confirm_delete_scene">Möchten Sie die Szene "%1$s" aus der App löschen?</string>
+    <string name="message_confirm_delete_scene_step">Möchten Sie den Szenenschritt löschen?</string>
+
     <string name="label_animation_type">Typ</string>
     <string name="label_animation_duration">Dauer</string>
     <string name="hint_animation_duration">(Sekunden)</string>

--- a/LifxTools/app/src/main/res/values-es/strings.xml
+++ b/LifxTools/app/src/main/res/values-es/strings.xml
@@ -11,7 +11,9 @@
     <string name="menu_stored_colors">Colores almacenados</string>
     <string name="menu_manage_devices">Administrar dispositivos</string>
     <string name="menu_alarms">Alarmas</string>
+    <string name="menu_scenes">Escenas</string>
     <string name="menu_alarm_configuration">Configuración de alarma</string>
+    <string name="menu_scene_configuration">Configuración de escena</string>
     <string name="menu_alarm_step_configuration">Configuración de paso de alarma</string>
     <string name="menu_general_settings">Configuración general</string>
     <string name="menu_settings">Configuraciones</string>
@@ -21,6 +23,7 @@
 
     <string name="color_off">APAGADA</string>
     <string name="default_alarm_name">Alarma %1$d</string>
+    <string name="default_scene_name">Escena %1$d</string>
     <string name="alarm_stopsequence_name">%1$s (Secuencia de parada)</string>
 
     <string name="notification_channel_animation">Animaciones LIFX</string>

--- a/LifxTools/app/src/main/res/values-es/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-es/strings_dialog.xml
@@ -79,6 +79,16 @@
     <string name="label_alarm_step_start">Inicio</string>
     <string name="label_alarm_step_end">Fin</string>
     <string name="hint_select_stored_color">(Seleccionar color almacenado)</string>
+    <string name="title_dialog_select_scene">Seleccionar escena</string>
+    <string name="title_dialog_change_scene_name">Cambiar nombre de la escena</string>
+    <string name="message_dialog_new_scene_name">Nuevo nombre de la escena:</string>
+    <string name="title_dialog_scene_step_delay">Retraso del paso de escena</string>
+    <string name="message_dialog_scene_step_delay">Establece el retraso del paso de la escena después de comenzar</string>
+    <string name="title_dialog_scene_step_duration">Duración del paso de escena</string>
+    <string name="message_dialog_scene_step_duration">Establece la duración del paso de la escena</string>
+    <string name="button_add_scene">Agregar escena</string>
+    <string name="message_confirm_delete_scene">¿Desea eliminar la escena "%1$s" de la aplicación?</string>
+    <string name="message_confirm_delete_scene_step">¿Desea eliminar el paso de escena?</string>
 
     <string name="label_animation_type">Tipo</string>
     <string name="label_animation_duration">Duración</string>

--- a/LifxTools/app/src/main/res/values-pt/strings.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings.xml
@@ -11,7 +11,9 @@
     <string name="menu_stored_colors">Cores armazenadas</string>
     <string name="menu_manage_devices">Gerenciar dispositivos</string>
     <string name="menu_alarms">Alarmes</string>
+    <string name="menu_scenes">Cenas</string>
     <string name="menu_alarm_configuration">Configuração de alarme</string>
+    <string name="menu_scene_configuration">Configuração de cena</string>
     <string name="menu_alarm_step_configuration">Configuração da etapa de alarme</string>
     <string name="menu_general_settings">Configurações Gerais</string>
     <string name="menu_settings">Configurações</string>
@@ -21,6 +23,7 @@
 
     <string name="color_off">FORA</string>
     <string name="default_alarm_name">Alarme %1$d</string>
+    <string name="default_scene_name">Cena %1$d</string>
     <string name="alarm_stopsequence_name">%1$s (Sequência de parada)</string>
 
     <string name="notification_channel_animation">Animações LIFX</string>

--- a/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
@@ -79,6 +79,16 @@
     <string name="label_alarm_step_start">Iniciar</string>
     <string name="label_alarm_step_end">Fim</string>
     <string name="hint_select_stored_color">(Selecione a cor armazenada)</string>
+    <string name="title_dialog_select_scene">Selecionar cena</string>
+    <string name="title_dialog_change_scene_name">Alterar nome da cena</string>
+    <string name="message_dialog_new_scene_name">Novo nome da cena:</string>
+    <string name="title_dialog_scene_step_delay">Atraso do passo da cena</string>
+    <string name="message_dialog_scene_step_delay">Defina o atraso do passo da cena após o início</string>
+    <string name="title_dialog_scene_step_duration">Duração do passo da cena</string>
+    <string name="message_dialog_scene_step_duration">Defina a duração do passo da cena</string>
+    <string name="button_add_scene">Adicionar cena</string>
+    <string name="message_confirm_delete_scene">Deseja excluir a cena "%1$s" do aplicativo?</string>
+    <string name="message_confirm_delete_scene_step">Deseja excluir o passo da cena?</string>
 
     <string name="label_animation_type">Tipo</string>
     <string name="label_animation_duration">Duração</string>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -3,6 +3,7 @@
     <string name="title_dialog_confirmation">Confirmation</string>
     <string name="title_dialog_select_light">Select Light</string>
     <string name="title_dialog_select_color">Select Color</string>
+    <string name="title_dialog_select_scene">Select Scene</string>
     <string name="title_dialog_save_color">Save Color</string>
     <string name="title_dialog_save_animation">Save Animation</string>
     <string name="title_dialog_image">Adapt image</string>


### PR DESCRIPTION
## Summary
- show a "Scenes" header at the top of the home list when scenes exist
- provide a dialog that lists stored scenes and runs the chosen one
- add resources and strings to support scenes selection

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68be007aa9f483228fbadde8aba64aaf