### PR TITLE
Fix variable spacing of scenes header on home screen

### DIFF
--- a/LifxTools/app/src/main/res/layout/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout/fragment_home.xml
@@ -8,20 +8,22 @@
     <ListView
         android:id="@android:id/list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
     <TextView
         android:id="@+id/textViewNoDevice"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="0dp"
         android:text="@string/message_searching_devices"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
@@ -1,18 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listelement_light_height"
+    android:layout_height="wrap_content"
     android:orientation="horizontal"
     android:paddingTop="@dimen/list_vertical_margin"
-    android:paddingBottom="@dimen/list_vertical_margin">
+    android:paddingBottom="@dimen/list_vertical_margin"
+    android:gravity="center_vertical">
 
     <TextView
         android:id="@+id/textViewScenes"
         android:layout_width="0dp"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/list_horizontal_margin"
         android:layout_weight="1"
-        android:gravity="center_vertical"
         android:text="@string/menu_scenes"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 


### PR DESCRIPTION
## Summary
- ensure scenes header height wraps content and is vertically centered to avoid excessive/variable space
- constrain home screen list and placeholder views to parent bounds to stabilize scenes header position

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be0c2940048322ac80254947e92427