### PR TITLE
Add scene launcher on home page

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
@@ -50,6 +50,8 @@ import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoredColors
 import de.jeisfeld.lifx.app.storedcolors.StoredMultizoneColors;
 import de.jeisfeld.lifx.app.storedcolors.StoredTileColors;
 import de.jeisfeld.lifx.app.util.ColorUtil;
+import de.jeisfeld.lifx.app.scenes.SceneRegistry;
+import de.jeisfeld.lifx.app.scenes.ScenesDialogFragment;
 import de.jeisfeld.lifx.app.util.DialogUtil;
 import de.jeisfeld.lifx.app.view.ColorPickerDialog;
 import de.jeisfeld.lifx.app.view.ColorPickerDialog.Builder;
@@ -127,7 +129,10 @@ public class DeviceAdapter extends BaseAdapter {
 		mFragment = new WeakReference<>(fragment);
 		mLifeCycleOwner = fragment.getViewLifecycleOwner();
 		mNoDeviceCallback = callback;
-		for (DeviceHolder device : mDevices) {
+                if (!SceneRegistry.getInstance().getScenes().isEmpty()) {
+                        mViewModels.add(0, new ScenesViewModel(mContext));
+                }
+                for (DeviceHolder device : mDevices) {
 			addViewModel(device);
 		}
 
@@ -153,7 +158,7 @@ public class DeviceAdapter extends BaseAdapter {
 
 	@Override
 	public final int getCount() {
-		return mDevices.size();
+		return mViewModels.size();
 	}
 
 	@Override
@@ -302,6 +307,32 @@ public class DeviceAdapter extends BaseAdapter {
 				mViews.add(position, view);
 			}
 		}
+
+                if (model instanceof ScenesViewModel) {
+                        if (checkBoxSelectLight != null) {
+                                checkBoxSelectLight.setVisibility(View.GONE);
+                        }
+                        view.findViewById(R.id.buttonPower).setVisibility(View.GONE);
+                        view.findViewById(R.id.buttonBrightnessColortemp).setVisibility(View.GONE);
+                        view.findViewById(R.id.buttonColorPicker).setVisibility(View.GONE);
+                        view.findViewById(R.id.buttonMultiColorPicker).setVisibility(View.GONE);
+                        view.findViewById(R.id.buttonImage).setVisibility(View.GONE);
+                        view.findViewById(R.id.buttonTune).setVisibility(View.GONE);
+                        view.findViewById(R.id.toggleButtonAnimation).setVisibility(View.GONE);
+                        view.findViewById(R.id.seekBarBrightness).setVisibility(View.GONE);
+                        Button saveButton = view.findViewById(R.id.buttonSave);
+                        if (saveButton != null) {
+                                saveButton.setVisibility(View.VISIBLE);
+                                Fragment fragment = mFragment.get();
+                                FragmentActivity activity = fragment == null ? null : fragment.getActivity();
+                                saveButton.setOnClickListener(v -> {
+                                        if (activity != null) {
+                                                ScenesDialogFragment.displayScenesDialog(activity);
+                                        }
+                                });
+                        }
+                        return view;
+                }
 
 		model.checkPower();
 
@@ -878,14 +909,15 @@ public class DeviceAdapter extends BaseAdapter {
 	 * @return the view model
 	 */
 	protected MainViewModel getViewModel(final String mac) {
-		for (int i = 0; i < mDevices.size(); i++) {
-			DeviceHolder holder = mDevices.get(i);
-			if (!holder.isGroup() && mac.equals(holder.getDevice().getTargetAddress())) {
-				return mViewModels.get(i);
-			}
-		}
-		return null;
-	}
+                int offset = mViewModels.size() - mDevices.size();
+                for (int i = 0; i < mDevices.size(); i++) {
+                        DeviceHolder holder = mDevices.get(i);
+                        if (!holder.isGroup() && mac.equals(holder.getDevice().getTargetAddress())) {
+                                return mViewModels.get(i + offset);
+                        }
+                }
+                return null;
+        }
 
 	/**
 	 * Get all checked devices.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/ScenesViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/ScenesViewModel.java
@@ -1,0 +1,49 @@
+package de.jeisfeld.lifx.app.home;
+
+import android.content.Context;
+
+import androidx.lifecycle.LiveData;
+
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.lan.type.Color;
+import de.jeisfeld.lifx.lan.type.Power;
+
+/**
+ * View model for scenes entry on home screen.
+ */
+public class ScenesViewModel extends MainViewModel {
+        /**
+         * Constructor.
+         *
+         * @param context the context
+         */
+        public ScenesViewModel(final Context context) {
+                super(context);
+        }
+
+        @Override
+        public CharSequence getLabel() {
+                Context ctx = getContext().get();
+                return ctx == null ? "" : ctx.getString(R.string.menu_scenes);
+        }
+
+        @Override
+        public void checkPower() {
+                // no device
+        }
+
+        @Override
+        public void togglePower() {
+                // no device
+        }
+
+        @Override
+        public LiveData<Color> getColor() {
+                return null;
+        }
+
+        @Override
+        public void updatePowerButton(final Power power) {
+                // ignore
+        }
+}

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/scenes/ScenesDialogFragment.java
@@ -1,0 +1,84 @@
+package de.jeisfeld.lifx.app.scenes;
+
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.GridView;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import java.util.Date;
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.DialogFragment;
+import androidx.fragment.app.FragmentActivity;
+import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.alarms.LifxAlarmService;
+
+/**
+ * Dialog for selecting a scene.
+ */
+public class ScenesDialogFragment extends DialogFragment {
+        /** Prevent recreation after orientation change. */
+        private static final String PREVENT_RECREATION = "preventRecreation";
+
+        /** Display the dialog. */
+        public static void displayScenesDialog(final FragmentActivity activity) {
+                ScenesDialogFragment fragment = new ScenesDialogFragment();
+                fragment.show(activity.getSupportFragmentManager(), fragment.getClass().toString());
+        }
+
+        @Override
+        @NonNull
+        public Dialog onCreateDialog(@Nullable final Bundle savedInstanceState) {
+                boolean preventRecreation = false;
+                if (savedInstanceState != null) {
+                        preventRecreation = savedInstanceState.getBoolean(PREVENT_RECREATION);
+                }
+                if (preventRecreation) {
+                        dismiss();
+                }
+
+                final View view = View.inflate(requireActivity(), R.layout.dialog_scenes, null);
+
+                final List<Scene> scenes = SceneRegistry.getInstance().getScenes();
+                if (!scenes.isEmpty()) {
+                        GridView gridView = view.findViewById(R.id.gridViewScenes);
+                        ArrayAdapter<Scene> adapter = new ArrayAdapter<Scene>(requireContext(), R.layout.grid_entry_select_color, scenes) {
+                                @Override
+                                public View getView(final int position, final View convertView, @NonNull final ViewGroup parent) {
+                                        final View newView = convertView == null
+                                                        ? View.inflate(requireActivity(), R.layout.grid_entry_select_color, null)
+                                                        : convertView;
+                                        final Scene scene = scenes.get(position);
+                                        ((TextView) newView.findViewById(R.id.textViewColorName)).setText(scene.getName());
+                                        ImageView imageView = newView.findViewById(R.id.imageViewApplyColor);
+                                        imageView.setImageResource(R.drawable.ic_menu_stored_colors);
+                                        imageView.setOnClickListener(v -> {
+                                                LifxAlarmService.triggerAlarmService(getContext(),
+                                                                LifxAlarmService.ACTION_TEST_SCENE, scene.getId(), new Date());
+                                                dismiss();
+                                        });
+                                        return newView;
+                                }
+                        };
+                        gridView.setAdapter(adapter);
+                }
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(requireActivity());
+                builder.setView(view);
+                builder.setNegativeButton(R.string.button_cancel, (dialog, id) -> { });
+                return builder.create();
+        }
+
+        @Override
+        public void onSaveInstanceState(@NonNull final Bundle outState) {
+                outState.putBoolean(PREVENT_RECREATION, true);
+                super.onSaveInstanceState(outState);
+        }
+}

--- a/LifxTools/app/src/main/res/layout/dialog_scenes.xml
+++ b/LifxTools/app/src/main/res/layout/dialog_scenes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="@dimen/activity_horizontal_margin">
+
+    <TextView
+        android:id="@+id/dialog_title_select"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/list_vertical_margin"
+        android:text="@string/title_dialog_select_scene" />
+
+    <GridView
+        android:id="@+id/gridViewScenes"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:numColumns="auto_fit"
+        android:columnWidth="@dimen/medium_button_size"
+        android:verticalSpacing="@dimen/small_margin"
+        android:horizontalSpacing="@dimen/small_margin"
+        android:stretchMode="columnWidth" />
+</LinearLayout>

--- a/LifxTools/app/src/main/res/values-de/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-de/strings_dialog.xml
@@ -3,6 +3,7 @@
     <string name="title_dialog_confirmation">Bestätigung</string>
     <string name="title_dialog_select_light">Licht wählen</string>
     <string name="title_dialog_select_color">Farbe wählen</string>
+    <string name="title_dialog_select_scene">Szene wählen</string>
     <string name="title_dialog_save_color">Farbe speichern</string>
     <string name="title_dialog_save_animation">Animation speichern</string>
     <string name="title_dialog_image">Bild anpassen</string>

--- a/LifxTools/app/src/main/res/values-es/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-es/strings_dialog.xml
@@ -3,6 +3,7 @@
     <string name="title_dialog_confirmation">Confirmación</string>
     <string name="title_dialog_select_light">Selecciona la luz</string>
     <string name="title_dialog_select_color">Selecciona el color</string>
+    <string name="title_dialog_select_scene">Seleccionar escena</string>
     <string name="title_dialog_save_color">Guardar color</string>
     <string name="title_dialog_save_animation">Guardar animación</string>
     <string name="title_dialog_image">Adaptar imagen</string>

--- a/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
@@ -3,6 +3,7 @@
     <string name="title_dialog_confirmation">Confirmação</string>
     <string name="title_dialog_select_light">Selecione a luz</string>
     <string name="title_dialog_select_color">Selecione a cor</string>
+    <string name="title_dialog_select_scene">Selecionar cena</string>
     <string name="title_dialog_save_color">Salvar cor</string>
     <string name="title_dialog_save_animation">Salvar animação</string>
     <string name="title_dialog_image">Adaptar imagem</string>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -3,6 +3,7 @@
     <string name="title_dialog_confirmation">Confirmation</string>
     <string name="title_dialog_select_light">Select Light</string>
     <string name="title_dialog_select_color">Select Color</string>
+    <string name="title_dialog_select_scene">Select Scene</string>
     <string name="title_dialog_save_color">Save Color</string>
     <string name="title_dialog_save_animation">Save Animation</string>
     <string name="title_dialog_image">Adapt image</string>


### PR DESCRIPTION
## Summary
- Show a "Scenes" entry above devices when scenes exist
- Provide dialog to select and run stored scenes
- Add translations and resources for the new scenes dialog

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68be007aa9f483228fbadde8aba64aaf