### PR TITLE
Move scenes header above list and show scene buttons row

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
@@ -12,11 +12,14 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.TextView;
 
 import com.skydoves.colorpickerview.ColorPickerView;
 import com.skydoves.colorpickerview.listeners.ColorListener;
 
+import java.util.Date;
 import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,6 +32,8 @@ import androidx.fragment.app.ListFragment;
 import de.jeisfeld.lifx.app.Application;
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.alarms.LifxAlarmService;
+import de.jeisfeld.lifx.app.scenes.Scene;
 import de.jeisfeld.lifx.app.scenes.SceneRegistry;
 import de.jeisfeld.lifx.app.scenes.ScenesDialogFragment;
 import de.jeisfeld.lifx.app.util.ColorUtil;
@@ -65,10 +70,6 @@ public class HomeFragment extends ListFragment {
 	 * The view creation time.
 	 */
 	private long mViewCreationTime;
-	/**
-	 * Header view for scenes selection.
-	 */
-	private View mScenesHeaderView;
 
 	/**
 	 * Send broadcast to home fragment informing about the end of an animation.
@@ -91,17 +92,16 @@ public class HomeFragment extends ListFragment {
 	public final void onViewCreated(@NonNull final View view, final Bundle savedInstanceState) {
 		super.onViewCreated(view, savedInstanceState);
 
-		mScenesHeaderView = LayoutInflater.from(getContext()).inflate(R.layout.list_view_home_scene, getListView(), false);
-		Button buttonScenes = mScenesHeaderView.findViewById(R.id.buttonScenes);
-		buttonScenes.setOnClickListener(v -> ScenesDialogFragment.displayScenesDialog(requireActivity()));
+                Button buttonScenes = requireView().findViewById(R.id.buttonScenes);
+                buttonScenes.setOnClickListener(v -> ScenesDialogFragment.displayScenesDialog(requireActivity()));
+                updateSceneButtons();
 
 		if (DeviceRegistry.getInstance().getDevices(false).size() == 0) {
 			getListView().setVisibility(View.GONE);
 			requireView().findViewById(R.id.textViewNoDevice).setVisibility(View.VISIBLE);
 		}
-		mAdapter = new DeviceAdapter(this, new NoDeviceCallback());
-		updateScenesHeaderVisibility();
-		setListAdapter(mAdapter);
+                mAdapter = new DeviceAdapter(this, new NoDeviceCallback());
+                setListAdapter(mAdapter);
 
 		ConstraintLayout layoutColorPicker = requireView().findViewById(R.id.layoutColorPicker);
 		ConstraintLayout layoutBrightnessColorTempPicker = requireView().findViewById(R.id.layoutBrightnessColorTempPicker);
@@ -125,7 +125,7 @@ public class HomeFragment extends ListFragment {
 	public final void onResume() {
 		super.onResume();
 
-		updateScenesHeaderVisibility();
+                updateSceneButtons();
 
 		ContextCompat.registerReceiver(requireActivity(), mReceiver, new IntentFilter(EXTRA_ANIMATION_STOP_INTENT), ContextCompat.RECEIVER_NOT_EXPORTED);
 
@@ -149,25 +149,30 @@ public class HomeFragment extends ListFragment {
 		requireActivity().unregisterReceiver(mReceiver);
 	}
 
-	/**
-	 * Update visibility of the scenes header depending on stored scenes.
-	 */
-	private void updateScenesHeaderVisibility() {
-		if (mScenesHeaderView != null) {
-			boolean hasScenes = !SceneRegistry.getInstance().getScenes().isEmpty();
-			if (hasScenes) {
-				if (mScenesHeaderView.getParent() == null) {
-					getListView().addHeaderView(mScenesHeaderView, null, false);
-					if (getListView().getAdapter() != null) {
-						setListAdapter(mAdapter);
-					}
-				}
-			}
-			else if (mScenesHeaderView.getParent() != null) {
-				getListView().removeHeaderView(mScenesHeaderView);
-			}
-		}
-	}
+        /**
+         * Populate the scene buttons shown above the list view.
+         */
+        private void updateSceneButtons() {
+                if (getView() == null) {
+                        return;
+                }
+                LinearLayout layout = getView().findViewById(R.id.layoutSceneButtons);
+                if (layout == null) {
+                        return;
+                }
+                layout.removeAllViews();
+                List<Scene> scenes = SceneRegistry.getInstance().getScenes();
+                LayoutInflater inflater = LayoutInflater.from(getContext());
+                for (Scene scene : scenes) {
+                        View sceneView = inflater.inflate(R.layout.grid_entry_scene, layout, false);
+                        ((TextView) sceneView.findViewById(R.id.textViewSceneName)).setText(scene.getName());
+                        ImageView imageView = sceneView.findViewById(R.id.imageViewRunScene);
+                        imageView.setOnClickListener(v ->
+                                        LifxAlarmService.triggerAlarmService(requireContext(),
+                                                        LifxAlarmService.ACTION_TEST_SCENE, scene.getId(), new Date()));
+                        layout.addView(sceneView);
+                }
+        }
 
 	/**
 	 * Prepare the color pickers shown in landscape view.

--- a/LifxTools/app/src/main/res/layout-land/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout-land/fragment_home.xml
@@ -15,13 +15,20 @@
         android:layout_height="match_parent"
         android:layout_weight="4">
 
-        <ListView
-            android:id="@android:id/list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+        <include
+            layout="@layout/list_view_home_scene"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
         <TextView
             android:id="@+id/textViewNoDevice"
@@ -32,7 +39,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/LifxTools/app/src/main/res/layout-sw600dp-land/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout-sw600dp-land/fragment_home.xml
@@ -15,13 +15,20 @@
         android:layout_height="match_parent"
         android:layout_weight="4">
 
-        <ListView
-            android:id="@android:id/list"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
+        <include
+            layout="@layout/list_view_home_scene"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <ListView
+            android:id="@android:id/list"
+            android:layout_width="0dp"
+            android:layout_height="0dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
         <TextView
             android:id="@+id/textViewNoDevice"
@@ -32,7 +39,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent" />
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/LifxTools/app/src/main/res/layout/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout/fragment_home.xml
@@ -5,13 +5,20 @@
     android:layout_height="match_parent"
     android:paddingHorizontal="@dimen/activity_margin">
 
-    <ListView
-        android:id="@android:id/list"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+    <include
+        layout="@layout/list_view_home_scene"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
+
+    <ListView
+        android:id="@android:id/list"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
     <TextView
         android:id="@+id/textViewNoDevice"
@@ -22,6 +29,6 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toTopOf="parent" />
+        app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
@@ -1,27 +1,48 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/layoutScenes"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="center_vertical"
-    android:orientation="horizontal"
+    android:orientation="vertical"
     android:paddingTop="@dimen/list_vertical_margin"
     android:paddingBottom="@dimen/list_vertical_margin">
 
     <TextView
         android:id="@+id/textViewScenes"
-        android:layout_width="0dp"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginStart="@dimen/list_horizontal_margin"
-        android:layout_weight="1"
-        android:gravity="center_vertical"
         android:text="@string/menu_scenes"
         android:textAppearance="?android:attr/textAppearanceMedium" />
 
-    <Button
-        android:id="@+id/buttonScenes"
-        android:layout_width="@dimen/medium_button_size"
-        android:layout_height="@dimen/medium_button_size"
-        android:layout_gravity="center_vertical|center_horizontal"
-        android:layout_marginEnd="@dimen/list_horizontal_margin"
-        android:background="@drawable/ic_menu_stored_colors" />
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/list_vertical_margin"
+        android:gravity="center_vertical"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/buttonScenes"
+            android:layout_width="@dimen/medium_button_size"
+            android:layout_height="@dimen/medium_button_size"
+            android:layout_marginStart="@dimen/list_horizontal_margin"
+            android:background="@drawable/ic_menu_stored_colors" />
+
+        <HorizontalScrollView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/list_horizontal_margin"
+            android:layout_marginEnd="@dimen/list_horizontal_margin"
+            android:layout_weight="1"
+            android:scrollbars="none">
+
+            <LinearLayout
+                android:id="@+id/layoutSceneButtons"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal" />
+        </HorizontalScrollView>
+    </LinearLayout>
+
 </LinearLayout>


### PR DESCRIPTION
## Summary
- Replaced list view header with a dedicated scenes layout above the list.
- Added a horizontal scrollable row of scene buttons with a save button on the left.
- Updated HomeFragment to populate and handle the new scene buttons.

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68be994b2dbc83229d053f2cd0f40200