### PR TITLE
Center scenes save icon and space scene buttons

### DIFF
--- a/LifxTools/app/src/main/res/layout/grid_entry_scene.xml
+++ b/LifxTools/app/src/main/res/layout/grid_entry_scene.xml
@@ -2,6 +2,8 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:layout_marginStart="@dimen/small_margin"
+    android:layout_marginEnd="@dimen/small_margin"
     android:layout_marginBottom="@dimen/small_margin"
     android:orientation="vertical">
 

--- a/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
+++ b/LifxTools/app/src/main/res/layout/list_view_home_scene.xml
@@ -20,7 +20,8 @@
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/list_vertical_margin"
         android:gravity="center_vertical"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        android:baselineAligned="false">
 
         <Button
             android:id="@+id/buttonScenes"


### PR DESCRIPTION
## Summary
- Center the scenes save button by disabling baseline alignment
- Add horizontal margin between scene buttons for better spacing

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beaafa2d948322afc8e74362ff27d1