### PR TITLE
Add separator between scenes and lights on home screen

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/HomeFragment.java
@@ -157,22 +157,35 @@ public class HomeFragment extends ListFragment {
 		if (getView() == null) {
 			return;
 		}
-		LinearLayout layout = getView().findViewById(R.id.layoutSceneButtons);
-		if (layout == null) {
-			return;
-		}
-		layout.removeAllViews();
-		List<Scene> scenes = SceneRegistry.getInstance().getScenes();
-		LayoutInflater inflater = LayoutInflater.from(getContext());
-		for (Scene scene : scenes) {
-			View sceneView = inflater.inflate(R.layout.grid_entry_scene, layout, false);
-			((TextView) sceneView.findViewById(R.id.textViewSceneName)).setText(scene.getName());
-			ImageView imageView = sceneView.findViewById(R.id.imageViewRunScene);
-			imageView.setOnClickListener(v ->
-					LifxAlarmService.triggerAlarmService(requireContext(),
-							LifxAlarmService.ACTION_TEST_SCENE, scene.getId(), new Date()));
-			layout.addView(sceneView);
-		}
+                LinearLayout layout = getView().findViewById(R.id.layoutSceneButtons);
+                View layoutScenes = getView().findViewById(R.id.layoutScenes);
+                View separatorScenes = getView().findViewById(R.id.separatorScenes);
+                if (layout == null || layoutScenes == null) {
+                        return;
+                }
+                layout.removeAllViews();
+                List<Scene> scenes = SceneRegistry.getInstance().getScenes();
+                if (scenes.isEmpty()) {
+                        layoutScenes.setVisibility(View.GONE);
+                        if (separatorScenes != null) {
+                                separatorScenes.setVisibility(View.GONE);
+                        }
+                        return;
+                }
+                layoutScenes.setVisibility(View.VISIBLE);
+                if (separatorScenes != null) {
+                        separatorScenes.setVisibility(View.VISIBLE);
+                }
+                LayoutInflater inflater = LayoutInflater.from(getContext());
+                for (Scene scene : scenes) {
+                        View sceneView = inflater.inflate(R.layout.grid_entry_scene, layout, false);
+                        ((TextView) sceneView.findViewById(R.id.textViewSceneName)).setText(scene.getName());
+                        ImageView imageView = sceneView.findViewById(R.id.imageViewRunScene);
+                        imageView.setOnClickListener(v ->
+                                        LifxAlarmService.triggerAlarmService(requireContext(),
+                                                        LifxAlarmService.ACTION_TEST_SCENE, scene.getId(), new Date()));
+                        layout.addView(sceneView);
+                }
 	}
 
 	/**

--- a/LifxTools/app/src/main/res/layout-land/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout-land/fragment_home.xml
@@ -21,6 +21,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <View
+            android:id="@+id/separatorScenes"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+
         <ListView
             android:id="@android:id/list"
             android:layout_width="0dp"
@@ -28,7 +37,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+            app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
         <TextView
             android:id="@+id/textViewNoDevice"
@@ -39,7 +48,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+            app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/LifxTools/app/src/main/res/layout-sw600dp-land/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout-sw600dp-land/fragment_home.xml
@@ -21,6 +21,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
+        <View
+            android:id="@+id/separatorScenes"
+            android:layout_width="0dp"
+            android:layout_height="1dp"
+            android:background="?android:attr/listDivider"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+
         <ListView
             android:id="@android:id/list"
             android:layout_width="0dp"
@@ -28,7 +37,7 @@
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+            app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
         <TextView
             android:id="@+id/textViewNoDevice"
@@ -39,7 +48,7 @@
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+            app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 

--- a/LifxTools/app/src/main/res/layout/fragment_home.xml
+++ b/LifxTools/app/src/main/res/layout/fragment_home.xml
@@ -11,6 +11,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent" />
 
+    <View
+        android:id="@+id/separatorScenes"
+        android:layout_width="0dp"
+        android:layout_height="1dp"
+        android:background="?android:attr/listDivider"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+
     <ListView
         android:id="@android:id/list"
         android:layout_width="0dp"
@@ -18,7 +27,7 @@
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+        app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
     <TextView
         android:id="@+id/textViewNoDevice"
@@ -29,6 +38,6 @@
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/layoutScenes" />
+        app:layout_constraintTop_toBottomOf="@id/separatorScenes" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- show thin divider between scenes header and first light on home screen
- update portrait, landscape, and tablet layouts

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68beb2a994448322ba42f3404eda5af7