### PR TITLE
feat: differentiate scene notifications

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
@@ -200,28 +200,28 @@ public class LifxAlarmService extends Service {
 				startNotification();
 			}
 		}
-		else if (ACTION_TRIGGER_ALARM.equals(action)) {
-			synchronized (ANIMATED_ALARMS) {
-				PENDING_ALARMS.remove(alarmId);
-			}
-			runAnimations(alarm, alarmDate);
-			AlarmReceiver.retriggerAlarm(this, alarm);
-		}
-		else if (ACTION_IMMEDIATE_ALARM.equals(action)) {
-			runAnimations(alarm, alarmDate);
-			AlarmReceiver.retriggerAlarm(this, alarm);
-		}
-		else if (ACTION_TEST_ALARM.equals(action)) {
-			runAnimations(alarm, alarmDate);
-		}
-		else if (ACTION_TEST_SCENE.equals(action)) {
-			Scene scene = SceneRegistry.getInstance().getScene(alarmId);
-			Alarm sceneAlarm = new Alarm(scene.getId(), true, alarmDate,
-					new HashSet<>(), scene.getName(),
-					scene.getSteps().stream().map(s -> new Step(s.getId(), s.getDelay(), s.getStoredColorId(), s.getDuration())).collect(Collectors.toList()),
-					AlarmType.STANDARD, null, false);
-			runAnimations(sceneAlarm, alarmDate);
-		}
+                else if (ACTION_TRIGGER_ALARM.equals(action)) {
+                        synchronized (ANIMATED_ALARMS) {
+                                PENDING_ALARMS.remove(alarmId);
+                        }
+                        runAnimations(alarm, alarmDate, false);
+                        AlarmReceiver.retriggerAlarm(this, alarm);
+                }
+                else if (ACTION_IMMEDIATE_ALARM.equals(action)) {
+                        runAnimations(alarm, alarmDate, false);
+                        AlarmReceiver.retriggerAlarm(this, alarm);
+                }
+                else if (ACTION_TEST_ALARM.equals(action)) {
+                        runAnimations(alarm, alarmDate, false);
+                }
+                else if (ACTION_TEST_SCENE.equals(action)) {
+                        Scene scene = SceneRegistry.getInstance().getScene(alarmId);
+                        Alarm sceneAlarm = new Alarm(scene.getId(), true, alarmDate,
+                                        new HashSet<>(), scene.getName(),
+                                        scene.getSteps().stream().map(s -> new Step(s.getId(), s.getDelay(), s.getStoredColorId(), s.getDuration())).collect(Collectors.toList()),
+                                        AlarmType.STANDARD, null, false);
+                        runAnimations(sceneAlarm, alarmDate, true);
+                }
 		else if (ACTION_INTERRUPT_ALARM.equals(action)) {
 			interruptAlarm(alarm);
 		}
@@ -242,23 +242,24 @@ public class LifxAlarmService extends Service {
 		return null;
 	}
 
-	/**
-	 * Run the animations for an alarm.
-	 *
-	 * @param alarm     the alarm
-	 * @param alarmDate the alarm date
-	 */
-	private void runAnimations(final Alarm alarm, final Date alarmDate) {
-		synchronized (ANIMATED_ALARMS) {
-			ANIMATED_ALARMS.add(alarm.getId());
-			startNotification();
-		}
-		for (BaseAnimationThread animationThread : getAnimationThreads(alarm, alarmDate)) {
-			animationThread.start();
-		}
+        /**
+         * Run the animations for an alarm or scene.
+         *
+         * @param alarm     the alarm
+         * @param alarmDate the alarm date
+         * @param isScene   true if triggered for a scene
+         */
+        private void runAnimations(final Alarm alarm, final Date alarmDate, final boolean isScene) {
+                synchronized (ANIMATED_ALARMS) {
+                        ANIMATED_ALARMS.add(alarm.getId());
+                        startNotification();
+                }
+                for (BaseAnimationThread animationThread : getAnimationThreads(alarm, alarmDate)) {
+                        animationThread.start();
+                }
 
-		startRunningNotification(alarm);
-	}
+                startRunningNotification(alarm, isScene);
+        }
 
 	/**
 	 * Get the animation threads for an alarm.
@@ -557,24 +558,27 @@ public class LifxAlarmService extends Service {
 	 *
 	 * @param alarm The alarm.
 	 */
-	private void startRunningNotification(final Alarm alarm) {
-		PendingIntent contentIntent = PendingIntent.getActivity(this, alarm.getId(),
-				MainActivity.createIntent(this, R.id.nav_alarms), PendingIntent.FLAG_IMMUTABLE);
-		PendingIntent stopIntent = PendingIntent.getService(this, alarm.getId(),
-				LifxAlarmService.createIntent(this, ACTION_INTERRUPT_ALARM, alarm.getId(), null), PendingIntent.FLAG_IMMUTABLE);
-		Notification notification = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID_EXECUTION)
-				.setContentTitle(getString(R.string.notification_title_alarm_execution, alarm.getName()))
-				.setSmallIcon(R.drawable.ic_notification_icon_alarm)
-				.setLargeIcon(ImageUtil.createBitmapFromDrawable(this, R.drawable.ic_notification_icon_large_alarm))
-				.setOngoing(true)
-				.setPriority(NotificationCompat.PRIORITY_HIGH)
-				.setContentIntent(contentIntent)
-				.addAction(R.drawable.ic_action_alarm_off, getString(R.string.notification_alarm_action_stop), stopIntent)
-				.build();
-		NotificationManager manager = getSystemService(NotificationManager.class);
-		assert manager != null;
-		manager.notify(NOTIFICATION_TAG_ALARM_EXECUTION, alarm.getId(), notification);
-	}
+        private void startRunningNotification(final Alarm alarm, final boolean isScene) {
+                PendingIntent contentIntent = PendingIntent.getActivity(this, alarm.getId(),
+                                MainActivity.createIntent(this, isScene ? R.id.nav_scenes : R.id.nav_alarms), PendingIntent.FLAG_IMMUTABLE);
+                PendingIntent stopIntent = PendingIntent.getService(this, alarm.getId(),
+                                LifxAlarmService.createIntent(this, ACTION_INTERRUPT_ALARM, alarm.getId(), null), PendingIntent.FLAG_IMMUTABLE);
+                int titleRes = isScene ? R.string.notification_title_scene_execution : R.string.notification_title_alarm_execution;
+                int smallIcon = isScene ? R.drawable.ic_menu_scenes : R.drawable.ic_notification_icon_alarm;
+                int largeIcon = isScene ? R.drawable.ic_menu_scenes : R.drawable.ic_notification_icon_large_alarm;
+                Notification notification = new NotificationCompat.Builder(this, NOTIFICATION_CHANNEL_ID_EXECUTION)
+                                .setContentTitle(getString(titleRes, alarm.getName()))
+                                .setSmallIcon(smallIcon)
+                                .setLargeIcon(ImageUtil.createBitmapFromDrawable(this, largeIcon))
+                                .setOngoing(true)
+                                .setPriority(NotificationCompat.PRIORITY_HIGH)
+                                .setContentIntent(contentIntent)
+                                .addAction(R.drawable.ic_action_alarm_off, getString(R.string.notification_alarm_action_stop), stopIntent)
+                                .build();
+                NotificationManager manager = getSystemService(NotificationManager.class);
+                assert manager != null;
+                manager.notify(NOTIFICATION_TAG_ALARM_EXECUTION, alarm.getId(), notification);
+        }
 
 	/**
 	 * End the animation for an alarm.

--- a/LifxTools/app/src/main/res/values-de/strings.xml
+++ b/LifxTools/app/src/main/res/values-de/strings.xml
@@ -33,6 +33,7 @@
     <string name="notification_channel_alarm_execution">LIFX-Alarm-Ausführung</string>
     <string name="notification_title_alarm">LIFX-Alarm</string>
     <string name="notification_title_alarm_execution">LIFX-Alarm %1$s</string>
+    <string name="notification_title_scene_execution">LIFX-Szene %1$s</string>
     <string name="notification_text_alarm">%2$s: %1$s\n</string>
     <string name="notification_text_no_alarm">Kein weiterer Alarm</string>
     <string name="notification_alarm_action_stop">Stopp</string>

--- a/LifxTools/app/src/main/res/values-es/strings.xml
+++ b/LifxTools/app/src/main/res/values-es/strings.xml
@@ -33,6 +33,7 @@
     <string name="notification_channel_alarm_execution">Ejecución de alarma LIFX</string>
     <string name="notification_title_alarm">Alarme LIFX</string>
     <string name="notification_title_alarm_execution">Alarme LIFX %1$s</string>
+    <string name="notification_title_scene_execution">Escena LIFX %1$s</string>
     <string name="notification_text_alarm">%2$s: %1$s\n</string>
     <string name="notification_text_no_alarm">No más alarmas</string>
     <string name="notification_alarm_action_stop">Detener</string>

--- a/LifxTools/app/src/main/res/values-pt/strings.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings.xml
@@ -33,6 +33,7 @@
     <string name="notification_channel_alarm_execution">Execução de alarme LIFX</string>
     <string name="notification_title_alarm">Alarme LIFX</string>
     <string name="notification_title_alarm_execution">Alarme LIFX %1$s</string>
+    <string name="notification_title_scene_execution">Cena LIFX %1$s</string>
     <string name="notification_text_alarm">%2$s: %1$s\n</string>
     <string name="notification_text_no_alarm">Sem mais alarmes</string>
     <string name="notification_alarm_action_stop">Pare</string>

--- a/LifxTools/app/src/main/res/values/strings.xml
+++ b/LifxTools/app/src/main/res/values/strings.xml
@@ -33,6 +33,7 @@
     <string name="notification_channel_alarm_execution">LIFX Alarm Execution</string>
     <string name="notification_title_alarm">LIFX Alarm</string>
     <string name="notification_title_alarm_execution">LIFX Alarm %1$s</string>
+    <string name="notification_title_scene_execution">LIFX Scene %1$s</string>
     <string name="notification_text_alarm">%2$s: %1$s\n</string>
     <string name="notification_text_no_alarm">No further alarms</string>
     <string name="notification_alarm_action_stop">Stop</string>


### PR DESCRIPTION
## Summary
- distinguish scene execution from alarm execution in foreground notifications
- add localized strings for scene execution title

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bebef0187883229b0714c3f7e5148b