### PR TITLE
Enable animations in alarms

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmConfigurationFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmConfigurationFragment.java
@@ -138,8 +138,8 @@ public class AlarmConfigurationFragment extends Fragment {
 							startRingtoneDialog(0, null);
 						}
 						else {
-							StoredColorsDialogFragment.displayStoredColorsDialog(
-									requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                                        StoredColorsDialogFragment.displayStoredColorsDialog(
+                                                                        requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, true,
 									(dialog, storedColor) -> {
 										mAlarm.getSteps().add(new Step(0, storedColor.getId(), DEFAULT_DURATION));
 										mAlarm = AlarmRegistry.getInstance().addOrUpdate(mAlarm);

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmStepExpandableListAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmStepExpandableListAdapter.java
@@ -211,8 +211,8 @@ public class AlarmStepExpandableListAdapter extends BaseExpandableListAdapter {
 					mFragment.startRingtoneDialog(newStartTime, null);
 				}
 				else {
-					StoredColorsDialogFragment.displayStoredColorsDialog(
-							mFragment.requireActivity(), (int) light.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                        StoredColorsDialogFragment.displayStoredColorsDialog(
+                                                        mFragment.requireActivity(), (int) light.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, true,
 							(dialog, storedColor) -> {
 								mAlarm.getSteps().add(new Step((int) newStartTime, storedColor.getId(), AlarmConfigurationFragment.DEFAULT_DURATION));
 								mAlarm = AlarmRegistry.getInstance().addOrUpdate(mAlarm);
@@ -275,8 +275,8 @@ public class AlarmStepExpandableListAdapter extends BaseExpandableListAdapter {
 				mFragment.startRingtoneDialog(step.getDelay(), (RingtoneStep) step);
 			}
 			else {
-				StoredColorsDialogFragment.displayStoredColorsDialog(
-						mFragment.requireActivity(), step.getStoredColor().getDeviceId(), StoreColorType.ONLYSELECT, true, false,
+                                StoredColorsDialogFragment.displayStoredColorsDialog(
+                                                mFragment.requireActivity(), step.getStoredColor().getDeviceId(), StoreColorType.ONLYSELECT, true, true,
 						(dialog, storedColor) -> {
 							Step newStep = new Step(step.getId(), step.getDelay(), storedColor.getId(), step.getDuration());
 							mAlarm.getSteps().remove(step);

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmsFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/AlarmsFragment.java
@@ -68,8 +68,8 @@ public class AlarmsFragment extends Fragment {
 					List<Light> lightsWithStoredColors = ColorRegistry.getInstance().getLightsWithStoredColors();
 					SelectDeviceDialogFragment.displaySelectDeviceDialog(requireActivity(),
 							device ->
-									StoredColorsDialogFragment.displayStoredColorsDialog(
-											requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, false,
+                                                                        StoredColorsDialogFragment.displayStoredColorsDialog(
+                                                                                        requireActivity(), (int) device.getParameter(DeviceRegistry.DEVICE_ID), StoreColorType.ONLYSELECT, true, true,
 											(dialog, storedColor) -> {
 												List<Step> steps = new ArrayList<>();
 												steps.add(new Step(0, storedColor.getId(), 10000)); // MAGIC_NUMBER


### PR DESCRIPTION
## Summary
- Allow selecting animation-based stored colors when creating new alarms.
- Include animations in alarm configuration dialogs for adding or editing steps.

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2bd37fdc48322abe0b9e5a7bdeb87