### PR TITLE
Fix stored animation handling for cyclic alarms and stop sequences

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/alarms/LifxAlarmService.java
@@ -340,10 +340,10 @@ public class LifxAlarmService extends Service {
 				}
 			}
 
-			if (hasStoredAnimation) {
-				animationThreads.add(new StoredAnimationThread(light, lightSteps.getSteps(), alarmDate)
-						.setAnimationCallback(callback));
-			}
+                        if (hasStoredAnimation) {
+                                animationThreads.add(new StoredAnimationThread(light, lightSteps.getSteps(), alarmDate,
+                                                alarm.getAlarmType(), alarm.getDuration()).setAnimationCallback(callback));
+                        }
 			else if (DeviceRegistry.getInstance().getRingtoneDummyLight().equals(light)) {
 				animationThreads.add(new RingtoneAnimationThread(
 						(RingtoneAnimationDefinition) getAnimationDefiniton(alarm, alarmDate, light, lightSteps.getSteps()))
@@ -710,36 +710,49 @@ public class LifxAlarmService extends Service {
 	/**
 	 * A thread handling stored animations within scenes or alarms.
 	 */
-	public class StoredAnimationThread extends Thread {
-		/**
-		 * The light that is animated.
-		 */
-		private final Light mLight;
-		/**
-		 * The steps for the light.
-		 */
-		private final List<Step> mSteps;
-		/**
-		 * The start date of the alarm or scene.
-		 */
-		private final Date mAlarmDate;
-		/**
-		 * An exception callback called in case of SocketException.
-		 */
-		private AnimationCallback mAnimationCallback = null;
+        public class StoredAnimationThread extends Thread {
+                /**
+                 * The light that is animated.
+                 */
+                private final Light mLight;
+                /**
+                 * The steps for the light.
+                 */
+                private final List<Step> mSteps;
+                /**
+                 * The start date of the alarm or scene.
+                 */
+                private final Date mAlarmDate;
+                /**
+                 * The alarm type.
+                 */
+                private final AlarmType mAlarmType;
+                /**
+                 * The total duration of the alarm.
+                 */
+                private final long mAlarmDuration;
+                /**
+                 * An exception callback called in case of SocketException.
+                 */
+                private AnimationCallback mAnimationCallback = null;
 
-		/**
-		 * Create an animation thread.
-		 *
-		 * @param light     The light.
-		 * @param steps     The steps for the light.
-		 * @param alarmDate The start date of the alarm or scene.
-		 */
-		protected StoredAnimationThread(final Light light, final List<Step> steps, final Date alarmDate) {
-			mLight = light;
-			mSteps = steps;
-			mAlarmDate = alarmDate;
-		}
+                /**
+                 * Create an animation thread.
+                 *
+                 * @param light        The light.
+                 * @param steps        The steps for the light.
+                 * @param alarmDate    The start date of the alarm or scene.
+                 * @param alarmType    The alarm type.
+                 * @param alarmDuration The total duration of the alarm.
+                 */
+                protected StoredAnimationThread(final Light light, final List<Step> steps, final Date alarmDate,
+                                final AlarmType alarmType, final long alarmDuration) {
+                        mLight = light;
+                        mSteps = steps;
+                        mAlarmDate = alarmDate;
+                        mAlarmType = alarmType;
+                        mAlarmDuration = alarmDuration;
+                }
 
 		/**
 		 * Set the exception callback called in case of Exception.
@@ -753,96 +766,119 @@ public class LifxAlarmService extends Service {
 		}
 
 		@Override
-		public void run() {
-			try {
-				LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
-				mLight.endAnimation(false);
-				for (int i = 0; i < mSteps.size(); i++) {
-					Step step = mSteps.get(i);
-					long start = mAlarmDate.getTime() + step.getDelay();
-					long waitTime = start - System.currentTimeMillis();
-					if (waitTime > 0) {
-						//noinspection BusyWait
-						Thread.sleep(waitTime);
-					}
+                public void run() {
+                        try {
+                                LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
+                                mLight.endAnimation(false);
+                                int n = 0;
+                                while (!isInterrupted() && (mAlarmType == AlarmType.CYCLIC || n < mSteps.size())) {
+                                        Step step = mSteps.get(n % mSteps.size());
+                                        long cycleStart = mAlarmDate.getTime() + (n / mSteps.size()) * mAlarmDuration;
+                                        long start = cycleStart + step.getDelay();
+                                        long waitTime = start - System.currentTimeMillis();
+                                        if (waitTime > 0) {
+                                                //noinspection BusyWait
+                                                Thread.sleep(waitTime);
+                                        }
 
-					if (i > 0 && mSteps.get(i - 1).getStoredColor() instanceof StoredAnimation) {
-						LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
-						mLight.endAnimation(false);
-					}
+                                        if (n > 0) {
+                                                Step previous = mSteps.get((n - 1) % mSteps.size());
+                                                if (previous.getStoredColor() instanceof StoredAnimation) {
+                                                        LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
+                                                        mLight.endAnimation(false);
+                                                }
+                                        }
 
-					StoredColor storedColor = step.getStoredColor();
-					if (storedColor instanceof StoredAnimation) {
-						StoredAnimation storedAnimation = (StoredAnimation) storedColor;
-						LifxAnimationService.triggerAnimationService(LifxAlarmService.this, mLight,
-								storedAnimation.getAnimationData());
-					}
-					else {
-						Color color = storedColor.getColor();
-						int duration = (int) step.getDuration();
-						Power power = mLight.getPower();
-						boolean wasOff = power != null && power.isOff();
-						if (mLight instanceof MultiZoneLight) {
-							MultizoneColors colors = storedColor instanceof StoredMultizoneColors
-									? ((StoredMultizoneColors) storedColor).getColors()
-									: new MultizoneColors.Fixed(color);
-							if (colors.isOff()) {
-								mLight.setPower(false, duration, false);
-							}
-							else if (wasOff) {
-								((MultiZoneLight) mLight).setColors(colors, 0, false);
-								mLight.setPower(true, duration, false);
-							}
-							else {
-								((MultiZoneLight) mLight).setColors(colors, duration, false);
-							}
-						}
-						else if (mLight instanceof TileChain) {
-							TileChainColors colors = storedColor instanceof StoredTileColors
-									? ((StoredTileColors) storedColor).getColors()
-									: new TileChainColors.Fixed(color);
-							if (colors.isOff()) {
-								mLight.setPower(false, duration, false);
-							}
-							else if (wasOff) {
-								((TileChain) mLight).setColors(colors, 0, false);
-								mLight.setPower(true, duration, false);
-							}
-							else {
-								((TileChain) mLight).setColors(colors, duration, false);
-							}
-						}
-						else {
-							if (color.isOff()) {
-								mLight.setPower(false, duration, false);
-							}
-							else if (wasOff) {
-								mLight.setColor(color, 0, false);
-								mLight.setPower(true, duration, false);
-							}
-							else {
-								mLight.setColor(color, duration, false);
-							}
-						}
-					}
-				}
-				if (mAnimationCallback != null) {
-					mAnimationCallback.onAnimationEnd(false);
-				}
-			}
-			catch (InterruptedException e) {
-				LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
-				mLight.endAnimation(true);
-				if (mAnimationCallback != null) {
-					mAnimationCallback.onAnimationEnd(true);
-				}
-			}
-			catch (IOException e) {
-				if (mAnimationCallback != null) {
-					mAnimationCallback.onException(e);
-				}
-			}
-		}
+                                        StoredColor storedColor = step.getStoredColor();
+                                        if (storedColor instanceof StoredAnimation) {
+                                                StoredAnimation storedAnimation = (StoredAnimation) storedColor;
+                                                LifxAnimationService.triggerAnimationService(LifxAlarmService.this, mLight,
+                                                                storedAnimation.getAnimationData());
+                                        }
+                                        else {
+                                                Color color = storedColor.getColor();
+                                                int duration = (int) step.getDuration();
+                                                Power power = mLight.getPower();
+                                                boolean wasOff = power != null && power.isOff();
+                                                if (mLight instanceof MultiZoneLight) {
+                                                        MultizoneColors colors = storedColor instanceof StoredMultizoneColors
+                                                                        ? ((StoredMultizoneColors) storedColor).getColors()
+                                                                        : new MultizoneColors.Fixed(color);
+                                                        if (colors.isOff()) {
+                                                                mLight.setPower(false, duration, false);
+                                                        }
+                                                        else if (wasOff) {
+                                                                ((MultiZoneLight) mLight).setColors(colors, 0, false);
+                                                                mLight.setPower(true, duration, false);
+                                                        }
+                                                        else {
+                                                                ((MultiZoneLight) mLight).setColors(colors, duration, false);
+                                                        }
+                                                }
+                                                else if (mLight instanceof TileChain) {
+                                                        TileChainColors colors = storedColor instanceof StoredTileColors
+                                                                        ? ((StoredTileColors) storedColor).getColors()
+                                                                        : new TileChainColors.Fixed(color);
+                                                        if (colors.isOff()) {
+                                                                mLight.setPower(false, duration, false);
+                                                        }
+                                                        else if (wasOff) {
+                                                                ((TileChain) mLight).setColors(colors, 0, false);
+                                                                mLight.setPower(true, duration, false);
+                                                        }
+                                                        else {
+                                                                ((TileChain) mLight).setColors(colors, duration, false);
+                                                        }
+                                                }
+                                                else {
+                                                        if (color.isOff()) {
+                                                                mLight.setPower(false, duration, false);
+                                                        }
+                                                        else if (wasOff) {
+                                                                mLight.setColor(color, 0, false);
+                                                                mLight.setPower(true, duration, false);
+                                                        }
+                                                        else {
+                                                                mLight.setColor(color, duration, false);
+                                                        }
+                                                }
+                                        }
+                                        n++;
+                                }
+
+                                if (!isInterrupted()) {
+                                        Step lastStep = mSteps.get((n - 1) % mSteps.size());
+                                        if (mAlarmType != AlarmType.CYCLIC && mAlarmType != AlarmType.STOP_MANUALLY) {
+                                                long end = mAlarmDate.getTime() + lastStep.getDelay() + lastStep.getDuration();
+                                                long waitTime = end - System.currentTimeMillis();
+                                                if (waitTime > 0) {
+                                                        //noinspection BusyWait
+                                                        Thread.sleep(waitTime);
+                                                }
+                                        }
+                                        if (mAlarmType != AlarmType.STOP_MANUALLY
+                                                        && lastStep.getStoredColor() instanceof StoredAnimation) {
+                                                LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
+                                                mLight.endAnimation(false);
+                                        }
+                                        if (mAnimationCallback != null) {
+                                                mAnimationCallback.onAnimationEnd(false);
+                                        }
+                                }
+                        }
+                        catch (InterruptedException e) {
+                                LifxAnimationService.stopAnimationForMac(LifxAlarmService.this, mLight.getTargetAddress());
+                                mLight.endAnimation(true);
+                                if (mAnimationCallback != null) {
+                                        mAnimationCallback.onAnimationEnd(true);
+                                }
+                        }
+                        catch (IOException e) {
+                                if (mAnimationCallback != null) {
+                                        mAnimationCallback.onException(e);
+                                }
+                        }
+                }
 
 		/**
 		 * Get the exception callback.


### PR DESCRIPTION
## Summary
- handle alarm type and duration in `StoredAnimationThread`
- properly cycle stored animations and stop last animation when required

## Testing
- `gradle :app:compileDebugJavaWithJavac` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c420109fd4832297728dc1ef5656aa