### PR TITLE
Fix stored animation startup flicker

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColor.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColor.java
@@ -243,12 +243,14 @@ public class StoredColor {
 					getLight().endAnimation(false);
 				}
 				setColor(colorDuration, model);
-				if (PreferenceUtil.getSharedPreferenceBoolean(R.string.key_pref_auto_on, true)) {
-					getLight().setPower(true);
-					if (model != null) {
-						model.updatePowerButton(Power.ON);
-					}
-				}
+                                if (!(this instanceof StoredAnimation)
+                                                && PreferenceUtil.getSharedPreferenceBoolean(
+                                                                R.string.key_pref_auto_on, true)) {
+                                        getLight().setPower(true);
+                                        if (model != null) {
+                                                model.updatePowerButton(Power.ON);
+                                        }
+                                }
 			}
 			catch (IOException e) {
 				Log.w(Application.TAG, e);


### PR DESCRIPTION
## Summary
- prevent StoredColor from powering on lights when starting a stored animation, avoiding a brief color reset

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68c42a0340fc8322a7f82a2b7c7c0f17