### PR TITLE
Enable color cycle animation for multizone and tilechain lights

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
@@ -5,6 +5,8 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.EditText;
 import android.widget.Spinner;
 
@@ -15,6 +17,7 @@ import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.MutableLiveData;
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.home.MultizoneViewModel;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
 import de.jeisfeld.lifx.lan.animation.MultizoneMoveDefinition;
 
 /**
@@ -87,9 +90,25 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 		}
 
 		final View view = View.inflate(requireActivity(), R.layout.dialog_multizone_animation, null);
-		final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
-		final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
-		final Spinner spinnerDirection = view.findViewById(R.id.spinnerDirection);
+                final Spinner spinnerType = view.findViewById(R.id.spinnerType);
+                final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
+                final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
+
+                spinnerType.setOnItemSelectedListener(new OnItemSelectedListener() {
+                        @Override
+                        public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position,
+                                        final long id) {
+                                if (position >= MultizoneMoveDefinition.Direction.values().length) {
+                                        openColorCycleDialog();
+                                        dismiss();
+                                }
+                        }
+
+                        @Override
+                        public void onNothingSelected(final AdapterView<?> parent) {
+                                // do nothing
+                        }
+                });
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 		builder.setTitle(R.string.title_dialog_animation)
@@ -118,15 +137,53 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 							stretch = 1;
 						}
 
-						MultizoneMoveDefinition.Direction direction =
-								MultizoneMoveDefinition.Direction.fromOrdinal(spinnerDirection.getSelectedItemPosition());
+                                                int position = spinnerType.getSelectedItemPosition();
+                                                if (position >= MultizoneMoveDefinition.Direction.values().length) {
+                                                        openColorCycleDialog();
+                                                }
+                                                else {
+                                                        MultizoneMoveDefinition.Direction direction =
+                                                                        MultizoneMoveDefinition.Direction.fromOrdinal(position);
 
-						mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
-								new MultizoneMove(duration, stretch, direction, mModel.getValue().getColors().getValue(), false));
-					}
-				});
-		return builder.create();
-	}
+                                                        mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
+                                                                        new MultizoneMove(duration, stretch, direction,
+                                                                                        mModel.getValue().getColors().getValue(), false));
+                                                }
+                                        }
+                                });
+                return builder.create();
+        }
+
+        /**
+         * Open the color cycle animation dialog.
+         */
+        private void openColorCycleDialog() {
+                FragmentActivity activity = getActivity();
+                if (activity != null && mModel != null && mModel.getValue() != null
+                                && mModel.getValue().getLight() != null
+                                && mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID) != null) {
+                        int deviceId = (int) mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID);
+                        ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(activity, mModel.getValue(), deviceId,
+                                        new ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener() {
+                                                @Override
+                                                public void onDialogPositiveClick(final DialogFragment dialog,
+                                                                final AnimationData animationData) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogPositiveClick(
+                                                                                MultizoneAnimationDialogFragment.this, animationData);
+                                                        }
+                                                }
+
+                                                @Override
+                                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogNegativeClick(
+                                                                                MultizoneAnimationDialogFragment.this);
+                                                        }
+                                                }
+                                        });
+                }
+        }
 
 	@Override
 	public final void onCancel(@Nonnull final DialogInterface dialogInterface) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
@@ -30,6 +30,7 @@ import de.jeisfeld.lifx.app.view.ColorPickerDialog;
 import de.jeisfeld.lifx.app.view.ColorPickerDialog.Builder;
 import de.jeisfeld.lifx.app.view.MultiColorPickerDialogFragment;
 import de.jeisfeld.lifx.app.view.MultiColorPickerDialogFragment.MultiColorPickerDialogListener;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
 import de.jeisfeld.lifx.lan.TileChain;
 import de.jeisfeld.lifx.lan.animation.TileChainWaveDefinition;
 import de.jeisfeld.lifx.lan.type.Color;
@@ -117,16 +118,13 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 
 		if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
 				&& mModel.getValue().getLight().getProduct().isChain()) {
-			ArrayList<String> items = new ArrayList<>(Arrays.asList(
-					getResources().getStringArray(R.array.values_tilechain_animation_type)));
-			if (items.size() > TileChainAnimationType.CLOUDS.ordinal()) {
-				items.remove(TileChainAnimationType.CLOUDS.ordinal());
-			}
-			ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
-					android.R.layout.simple_spinner_item, items);
-			adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-			spinnerAnimationType.setAdapter(adapter);
-		}
+                        ArrayList<String> items = new ArrayList<>(Arrays.asList(
+                                        getResources().getStringArray(R.array.values_tilechain_animation_type)));
+                        ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
+                                        android.R.layout.simple_spinner_item, items);
+                        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                        spinnerAnimationType.setAdapter(adapter);
+                }
 
 		prepareSpinnerListener(parentView, spinnerAnimationType);
 
@@ -225,13 +223,16 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 								cloudSaturation = 50;
 							}
 							cloudSaturation = Math.max(0, Math.min(255, cloudSaturation));
-							mListener.getValue().onDialogPositiveClick(TileChainAnimationDialogFragment.this,
-									new TileChainClouds(duration * 5, cloudSaturation, mColors, false));
-							break;
-						case WAVE:
-						default:
-							double lightRadius =
-									Math.sqrt(light.getTotalHeight() * light.getTotalHeight() + light.getTotalWidth() * light.getTotalWidth()) / 2;
+                                                        mListener.getValue().onDialogPositiveClick(TileChainAnimationDialogFragment.this,
+                                                                        new TileChainClouds(duration * 5, cloudSaturation, mColors, false));
+                                                        break;
+                                                case COLOR_CYCLE:
+                                                        openColorCycleDialog();
+                                                        break;
+                                                case WAVE:
+                                                default:
+                                                        double lightRadius =
+                                                                        Math.sqrt(light.getTotalHeight() * light.getTotalHeight() + light.getTotalWidth() * light.getTotalWidth()) / 2;
 
 							double radius;
 							try {
@@ -262,8 +263,8 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 	 * @param parentView           The dialog parent view.
 	 * @param spinnerAnimationType The spinner.
 	 */
-	private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType) {
-		spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
+        private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType) {
+                spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position, final long id) {
 				TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(position);
@@ -308,25 +309,60 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 					ImageView imageViewColors = parentView.findViewById(R.id.imageViewColors);
 					imageViewColors.setImageDrawable(ColorUtil.getButtonDrawable(getContext(), mColors));
 					break;
-				case WAVE:
-				default:
-					parentView.findViewById(R.id.tableRowRadius).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowDirection).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowForm).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowColors).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
-					break;
-				}
-			}
+                                case COLOR_CYCLE:
+                                        openColorCycleDialog();
+                                        dismiss();
+                                        break;
+                                case WAVE:
+                                default:
+                                        parentView.findViewById(R.id.tableRowRadius).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowDirection).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowForm).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowColors).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
+                                        break;
+                                }
+                        }
 
 			@Override
 			public void onNothingSelected(final AdapterView<?> parent) {
 				// do nothing
-			}
-		});
-	}
+                        }
+                });
+        }
+
+        /**
+         * Open the color cycle animation dialog.
+         */
+        private void openColorCycleDialog() {
+                FragmentActivity activity = getActivity();
+                if (activity != null && mModel != null && mModel.getValue() != null
+                                && mModel.getValue().getLight() != null
+                                && mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID) != null) {
+                        int deviceId = (int) mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID);
+                        ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(activity, mModel.getValue(), deviceId,
+                                        new ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener() {
+                                                @Override
+                                                public void onDialogPositiveClick(final DialogFragment dialog,
+                                                                final AnimationData animationData) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogPositiveClick(
+                                                                                TileChainAnimationDialogFragment.this, animationData);
+                                                        }
+                                                }
+
+                                                @Override
+                                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogNegativeClick(
+                                                                                TileChainAnimationDialogFragment.this);
+                                                        }
+                                                }
+                                        });
+                }
+        }
 
 	@Override
 	public final void onCancel(@Nonnull final DialogInterface dialogInterface) {
@@ -368,7 +404,11 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 		/**
 		 * Clouds.
 		 */
-		CLOUDS;
+                CLOUDS,
+                /**
+                 * Color cycle.
+                 */
+                COLOR_CYCLE;
 
 		/**
 		 * Get TileChainAnimationType from its ordinal value.

--- a/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
+++ b/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
@@ -10,6 +10,21 @@
     <TableRow>
 
         <TextView
+            android:text="@string/label_animation_type"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <Spinner
+            android:id="@+id/spinnerType"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/values_multizone_animation_type"
+            android:minHeight="@dimen/medium_button_size"
+            android:spinnerMode="dropdown" />
+    </TableRow>
+
+    <TableRow>
+
+        <TextView
             android:text="@string/label_animation_duration"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -41,18 +56,4 @@
             tools:ignore="HardcodedText" />
     </TableRow>
 
-    <TableRow>
-
-        <TextView
-            android:text="@string/label_animation_direction"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <Spinner
-            android:id="@+id/spinnerDirection"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/values_multizone_animation_direction"
-            android:minHeight="@dimen/medium_button_size"
-            android:spinnerMode="dropdown" />
-    </TableRow>
 </TableLayout>

--- a/LifxTools/app/src/main/res/values-de/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-de/strings_dialog.xml
@@ -106,11 +106,12 @@
     <string name="label_minutes">Minuten</string>
     <string name="label_seconds">Sekunden</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>vorwärts</item>
         <item>rückwärts</item>
         <item>auswärts</item>
         <item>einwärts</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>Welle</item>
@@ -118,6 +119,7 @@
         <item>Flamme</item>
         <item>Metamorphose</item>
         <item>Wolken</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>auswärts</item>

--- a/LifxTools/app/src/main/res/values-es/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-es/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>adelante</item>
         <item>hacia atrás</item>
         <item>hacia fuera</item>
         <item>hacia adentro</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>ola</item>
@@ -117,6 +118,7 @@
         <item>fuego</item>
         <item>metamorfosis</item>
         <item>nubes</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>hacia fuera</item>

--- a/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>frente</item>
         <item>para trás</item>
         <item>para fora</item>
         <item>para dentro</item>
+        <item>ciclo de cor</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>onda</item>
@@ -117,6 +118,7 @@
         <item>chama</item>
         <item>metamorfose</item>
         <item>nuvens</item>
+        <item>ciclo de cor</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>para fora</item>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutes</string>
     <string name="label_seconds">Seconds</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>forward</item>
         <item>backward</item>
         <item>outward</item>
         <item>inward</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>wave</item>
@@ -117,6 +118,7 @@
         <item>flame</item>
         <item>morph</item>
         <item>clouds</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>outward</item>


### PR DESCRIPTION
## Summary
- Add color cycle option to multizone animation dialog and launch dedicated color cycle configuration
- Extend tile chain animation settings to support color cycle selection
- Update resources and layouts for new animation type and translated strings

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a77a708883229478c3e1120e158e