### PR TITLE
Enable color cycle animation for multizone and tile lights

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
@@ -7,6 +7,9 @@ import android.os.Bundle;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.Spinner;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemSelectedListener;
+import android.widget.TableRow;
 
 import javax.annotation.Nonnull;
 
@@ -14,7 +17,10 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.MutableLiveData;
 import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.animation.ColorCycleAnimationDialogFragment;
+import de.jeisfeld.lifx.app.animation.ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener;
 import de.jeisfeld.lifx.app.home.MultizoneViewModel;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
 import de.jeisfeld.lifx.lan.animation.MultizoneMoveDefinition;
 
 /**
@@ -86,10 +92,32 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 			dismiss();
 		}
 
-		final View view = View.inflate(requireActivity(), R.layout.dialog_multizone_animation, null);
-		final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
-		final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
-		final Spinner spinnerDirection = view.findViewById(R.id.spinnerDirection);
+                final View view = View.inflate(requireActivity(), R.layout.dialog_multizone_animation, null);
+                final Spinner spinnerType = view.findViewById(R.id.spinnerType);
+                final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
+                final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
+                final TableRow tableRowDuration = view.findViewById(R.id.tableRowDuration);
+                final TableRow tableRowStretch = view.findViewById(R.id.tableRowStretch);
+
+                spinnerType.setOnItemSelectedListener(new OnItemSelectedListener() {
+                        @Override
+                        public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position,
+                                                                 final long id) {
+                                if (position >= MultizoneMoveDefinition.Direction.values().length) {
+                                        tableRowDuration.setVisibility(View.GONE);
+                                        tableRowStretch.setVisibility(View.GONE);
+                                }
+                                else {
+                                        tableRowDuration.setVisibility(View.VISIBLE);
+                                        tableRowStretch.setVisibility(View.VISIBLE);
+                                }
+                        }
+
+                        @Override
+                        public void onNothingSelected(final AdapterView<?> parent) {
+                                // do nothing
+                        }
+                });
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 		builder.setTitle(R.string.title_dialog_animation)
@@ -100,31 +128,59 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 						mListener.getValue().onDialogNegativeClick(MultizoneAnimationDialogFragment.this);
 					}
 				})
-				.setPositiveButton(R.string.button_start, (dialog, id) -> {
-					// Send the negative button event back to the host activity
-					if (mListener != null && mListener.getValue() != null && mModel != null && mModel.getValue() != null) {
-						int duration;
-						try {
-							duration = (int) (Double.parseDouble(editTextDuration.getText().toString()) * 1000); // MAGIC_NUMBER
-						}
-						catch (Exception e) {
-							duration = 10000; // MAGIC_NUMBER
-						}
-						double stretch;
-						try {
-							stretch = Math.max(0.1, Double.parseDouble(editTextStretch.getText().toString())); // MAGIC_NUMBER
-						}
-						catch (Exception e) {
-							stretch = 1;
-						}
+                                .setPositiveButton(R.string.button_start, (dialog, id) -> {
+                                        // Send the negative button event back to the host activity
+                                        if (mListener != null && mListener.getValue() != null && mModel != null
+                                                        && mModel.getValue() != null) {
+                                                int type = spinnerType.getSelectedItemPosition();
+                                                if (type >= MultizoneMoveDefinition.Direction.values().length) {
+                                                        if (mModel.getValue().getLight() != null
+                                                                        && mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID) != null) {
+                                                                int deviceId = (int) mModel.getValue().getLight().getParameter(DeviceRegistry.DEVICE_ID);
+                                                                FragmentActivity activity = getActivity();
+                                                                if (activity != null) {
+                                                                        ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(
+                                                                                        activity, mModel.getValue(), deviceId,
+                                                                                        new ColorCycleAnimationDialogListener() {
+                                                                                                @Override
+                                                                                                public void onDialogPositiveClick(final DialogFragment dialogFragment,
+                                                                                                                final AnimationData animationData) {
+                                                                                                        mListener.getValue().onDialogPositiveClick(dialogFragment, animationData);
+                                                                                                }
 
-						MultizoneMoveDefinition.Direction direction =
-								MultizoneMoveDefinition.Direction.fromOrdinal(spinnerDirection.getSelectedItemPosition());
+                                                                                                @Override
+                                                                                                public void onDialogNegativeClick(final DialogFragment dialogFragment) {
+                                                                                                        mListener.getValue().onDialogNegativeClick(dialogFragment);
+                                                                                                }
+                                                                                        });
+                                                                }
+                                                        }
+                                                }
+                                                else {
+                                                        int duration;
+                                                        try {
+                                                                duration = (int) (Double.parseDouble(editTextDuration.getText().toString()) * 1000); // MAGIC_NUMBER
+                                                        }
+                                                        catch (Exception e) {
+                                                                duration = 10000; // MAGIC_NUMBER
+                                                        }
+                                                        double stretch;
+                                                        try {
+                                                                stretch = Math.max(0.1, Double.parseDouble(editTextStretch.getText().toString())); // MAGIC_NUMBER
+                                                        }
+                                                        catch (Exception e) {
+                                                                stretch = 1;
+                                                        }
 
-						mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
-								new MultizoneMove(duration, stretch, direction, mModel.getValue().getColors().getValue(), false));
-					}
-				});
+                                                        MultizoneMoveDefinition.Direction direction =
+                                                                        MultizoneMoveDefinition.Direction.fromOrdinal(type);
+
+                                                        mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
+                                                                        new MultizoneMove(duration, stretch, direction,
+                                                                                        mModel.getValue().getColors().getValue(), false));
+                                                }
+                                        }
+                                });
 		return builder.create();
 	}
 

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
@@ -24,7 +24,10 @@ import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentActivity;
 import androidx.lifecycle.MutableLiveData;
 import de.jeisfeld.lifx.app.R;
+import de.jeisfeld.lifx.app.animation.ColorCycleAnimationDialogFragment;
+import de.jeisfeld.lifx.app.animation.ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener;
 import de.jeisfeld.lifx.app.home.TileViewModel;
+import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
 import de.jeisfeld.lifx.app.util.ColorUtil;
 import de.jeisfeld.lifx.app.view.ColorPickerDialog;
 import de.jeisfeld.lifx.app.view.ColorPickerDialog.Builder;
@@ -115,20 +118,23 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 		final EditText editTextCloudSaturation = parentView.findViewById(R.id.editTextCloudSaturation);
 		final ImageView imageViewColors = parentView.findViewById(R.id.imageViewColors);
 
-		if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
-				&& mModel.getValue().getLight().getProduct().isChain()) {
-			ArrayList<String> items = new ArrayList<>(Arrays.asList(
-					getResources().getStringArray(R.array.values_tilechain_animation_type)));
-			if (items.size() > TileChainAnimationType.CLOUDS.ordinal()) {
-				items.remove(TileChainAnimationType.CLOUDS.ordinal());
-			}
-			ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
-					android.R.layout.simple_spinner_item, items);
-			adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-			spinnerAnimationType.setAdapter(adapter);
-		}
+                boolean cloudsRemovedTemp = false;
+                if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
+                                && mModel.getValue().getLight().getProduct().isChain()) {
+                        ArrayList<String> items = new ArrayList<>(Arrays.asList(
+                                        getResources().getStringArray(R.array.values_tilechain_animation_type)));
+                        if (items.size() > TileChainAnimationType.CLOUDS.ordinal()) {
+                                items.remove(TileChainAnimationType.CLOUDS.ordinal());
+                                cloudsRemovedTemp = true;
+                        }
+                        ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
+                                        android.R.layout.simple_spinner_item, items);
+                        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                        spinnerAnimationType.setAdapter(adapter);
+                }
+                final boolean cloudsRemoved = cloudsRemovedTemp;
 
-		prepareSpinnerListener(parentView, spinnerAnimationType);
+                prepareSpinnerListener(parentView, spinnerAnimationType, cloudsRemoved);
 
 		mColors.add(Color.RED);
 		mColors.add(Color.GREEN);
@@ -189,8 +195,12 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 					// Send the negative button event back to the host activity
 					if (mListener != null && mListener.getValue() != null && mModel != null // BOOLEAN_EXPRESSION_COMPLEXITY
 							&& mModel.getValue() != null && mModel.getValue().getLight() != null) {
-						TileChain light = mModel.getValue().getLight();
-						TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(spinnerAnimationType.getSelectedItemPosition());
+                                                TileChain light = mModel.getValue().getLight();
+                                                int position = spinnerAnimationType.getSelectedItemPosition();
+                                                if (cloudsRemoved && position >= TileChainAnimationType.CLOUDS.ordinal()) {
+                                                        position++;
+                                                }
+                                                TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(position);
 
 						int duration;
 						try {
@@ -200,10 +210,32 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 							duration = 10000; // MAGIC_NUMBER
 						}
 
-						switch (animationType) {
-						case IMAGE_TRANSITION:
-							String colorRegex = editTextColorRegex.getText().toString();
-							boolean adjustBrightness = checkBoxAdjustBrightness.isChecked();
+                                                switch (animationType) {
+                                                case COLOR_CYCLE:
+                                                        if (light.getParameter(DeviceRegistry.DEVICE_ID) != null) {
+                                                                int deviceId = (int) light.getParameter(DeviceRegistry.DEVICE_ID);
+                                                                FragmentActivity activity = getActivity();
+                                                                if (activity != null) {
+                                                                        ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(
+                                                                                        activity, mModel.getValue(), deviceId,
+                                                                                        new ColorCycleAnimationDialogListener() {
+                                                                                                @Override
+                                                                                                public void onDialogPositiveClick(final DialogFragment dialog,
+                                                                                                                final AnimationData animationData) {
+                                                                                                        mListener.getValue().onDialogPositiveClick(dialog, animationData);
+                                                                                                }
+
+                                                                                                @Override
+                                                                                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                                                                        mListener.getValue().onDialogNegativeClick(dialog);
+                                                                                                }
+                                                                                        });
+                                                                }
+                                                        }
+                                                        break;
+                                                case IMAGE_TRANSITION:
+                                                        String colorRegex = editTextColorRegex.getText().toString();
+                                                        boolean adjustBrightness = checkBoxAdjustBrightness.isChecked();
 
 							mListener.getValue().onDialogPositiveClick(TileChainAnimationDialogFragment.this,
 									new TileChainImageTransition(duration, colorRegex, adjustBrightness));
@@ -262,17 +294,33 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 	 * @param parentView           The dialog parent view.
 	 * @param spinnerAnimationType The spinner.
 	 */
-	private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType) {
-		spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
+        private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType,
+                        final boolean cloudsRemoved) {
+                spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position, final long id) {
-				TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(position);
-				switch (animationType) {
-				case IMAGE_TRANSITION:
-					parentView.findViewById(R.id.tableRowRadius).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowDirection).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowForm).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowColors).setVisibility(View.GONE);
+                                int adjustedPosition = position;
+                                if (cloudsRemoved && position >= TileChainAnimationType.CLOUDS.ordinal()) {
+                                        adjustedPosition++;
+                                }
+                                TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(adjustedPosition);
+                                parentView.findViewById(R.id.tableRowDuration).setVisibility(View.VISIBLE);
+                                switch (animationType) {
+                                case COLOR_CYCLE:
+                                        parentView.findViewById(R.id.tableRowDuration).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowRadius).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowDirection).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowForm).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowColors).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
+                                        break;
+                                case IMAGE_TRANSITION:
+                                        parentView.findViewById(R.id.tableRowRadius).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowDirection).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowForm).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowColors).setVisibility(View.GONE);
 					parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.VISIBLE);
 					parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.VISIBLE);
 					parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
@@ -348,27 +396,31 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 	/**
 	 * The direction of the animation.
 	 */
-	public enum TileChainAnimationType {
-		/**
-		 * Wave.
-		 */
-		WAVE,
-		/**
-		 * Image transition.
-		 */
-		IMAGE_TRANSITION,
-		/**
-		 * Flame.
-		 */
-		FLAME,
-		/**
-		 * Morph.
-		 */
-		MORPH,
-		/**
-		 * Clouds.
-		 */
-		CLOUDS;
+        public enum TileChainAnimationType {
+                /**
+                 * Wave.
+                 */
+                WAVE,
+                /**
+                 * Image transition.
+                 */
+                IMAGE_TRANSITION,
+                /**
+                 * Flame.
+                 */
+                FLAME,
+                /**
+                 * Morph.
+                 */
+                MORPH,
+                /**
+                 * Clouds.
+                 */
+                CLOUDS,
+                /**
+                 * Color cycle.
+                 */
+                COLOR_CYCLE;
 
 		/**
 		 * Get TileChainAnimationType from its ordinal value.

--- a/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
+++ b/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
@@ -7,7 +7,24 @@
     android:paddingEnd="?attr/dialogPreferredPadding"
     android:stretchColumns="1">
 
-    <TableRow>
+    <TableRow
+        android:id="@+id/tableRowType">
+
+        <TextView
+            android:text="@string/label_animation_type"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <Spinner
+            android:id="@+id/spinnerType"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/values_multizone_animation_type"
+            android:minHeight="@dimen/medium_button_size"
+            android:spinnerMode="dropdown" />
+    </TableRow>
+
+    <TableRow
+        android:id="@+id/tableRowDuration">
 
         <TextView
             android:text="@string/label_animation_duration"
@@ -24,7 +41,8 @@
             tools:ignore="HardcodedText" />
     </TableRow>
 
-    <TableRow>
+    <TableRow
+        android:id="@+id/tableRowStretch">
 
         <TextView
             android:labelFor="@id/editTextStretch"
@@ -39,20 +57,5 @@
             android:inputType="numberDecimal"
             android:text="1"
             tools:ignore="HardcodedText" />
-    </TableRow>
-
-    <TableRow>
-
-        <TextView
-            android:text="@string/label_animation_direction"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <Spinner
-            android:id="@+id/spinnerDirection"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/values_multizone_animation_direction"
-            android:minHeight="@dimen/medium_button_size"
-            android:spinnerMode="dropdown" />
     </TableRow>
 </TableLayout>

--- a/LifxTools/app/src/main/res/values-de/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-de/strings_dialog.xml
@@ -106,11 +106,12 @@
     <string name="label_minutes">Minuten</string>
     <string name="label_seconds">Sekunden</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>vorwärts</item>
         <item>rückwärts</item>
         <item>auswärts</item>
         <item>einwärts</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>Welle</item>
@@ -118,6 +119,7 @@
         <item>Flamme</item>
         <item>Metamorphose</item>
         <item>Wolken</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>auswärts</item>

--- a/LifxTools/app/src/main/res/values-es/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-es/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>adelante</item>
         <item>hacia atrás</item>
         <item>hacia fuera</item>
         <item>hacia adentro</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>ola</item>
@@ -117,6 +118,7 @@
         <item>fuego</item>
         <item>metamorfosis</item>
         <item>nubes</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>hacia fuera</item>

--- a/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>frente</item>
         <item>para trás</item>
         <item>para fora</item>
         <item>para dentro</item>
+        <item>ciclo de cores</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>onda</item>
@@ -117,6 +118,7 @@
         <item>chama</item>
         <item>metamorfose</item>
         <item>nuvens</item>
+        <item>ciclo de cores</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>para fora</item>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutes</string>
     <string name="label_seconds">Seconds</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>forward</item>
         <item>backward</item>
         <item>outward</item>
         <item>inward</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>wave</item>
@@ -117,6 +118,7 @@
         <item>flame</item>
         <item>morph</item>
         <item>clouds</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>outward</item>


### PR DESCRIPTION
## Summary
- allow TileChain lights to trigger ColorCycle by adding a new animation type
- add a Type selector for multizone animations and hook up ColorCycle when chosen
- expose new animation options through updated layout and string resources

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a77a708883229478c3e1120e158e