### PR TITLE
Enable color cycle animation for multizone and tilechain lights

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
@@ -10,6 +10,8 @@ import java.util.ArrayList;
 
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
+import de.jeisfeld.lifx.app.storedcolors.ColorRegistry;
+import de.jeisfeld.lifx.app.storedcolors.StoredColor;
 import de.jeisfeld.lifx.app.storedcolors.StoredMultizoneColors;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
 import de.jeisfeld.lifx.lan.Light;
@@ -72,10 +74,14 @@ public abstract class AnimationData implements Serializable {
 	 * Key for the multizone colors within the intent.
 	 */
 	protected static final String EXTRA_MULTIZONE_COLORS = "de.jeisfeld.lifx.MULTIZONE_COLORS";
-	/**
-	 * Key for a list of colors within the intent.
-	 */
-	protected static final String EXTRA_COLOR_LIST = "de.jeisfeld.lifx.COLOR_LIST";
+        /**
+         * Key for a list of colors within the intent.
+         */
+        protected static final String EXTRA_COLOR_LIST = "de.jeisfeld.lifx.COLOR_LIST";
+        /**
+         * Key for a list of stored color ids within the intent.
+         */
+        protected static final String EXTRA_STORED_COLOR_IDS = "de.jeisfeld.lifx.STORED_COLOR_IDS";
 	/**
 	 * Key for a list of step durations within the intent.
 	 */
@@ -235,19 +241,25 @@ public abstract class AnimationData implements Serializable {
 			final int cloudSaturation = intent.getIntExtra(EXTRA_ANIMATION_CLOUD_SATURATION, (byte) 50);
 			@SuppressWarnings("unchecked") final ArrayList<Color> tileColors3 = (ArrayList<Color>) intent.getSerializableExtra(EXTRA_COLOR_LIST);
 			return new TileChainClouds(duration, cloudSaturation, tileColors3, false);
-		case COLOR_CYCLE:
-			int[] durationsArray = intent.getIntArrayExtra(EXTRA_ANIMATION_DURATIONS);
-			ArrayList<Integer> cycleDurations = new ArrayList<>();
-			if (durationsArray != null) {
-				for (int d : durationsArray) {
-					cycleDurations.add(d);
-				}
-			}
-			@SuppressWarnings("unchecked") ArrayList<Color> cycleColors = (ArrayList<Color>) intent.getSerializableExtra(EXTRA_COLOR_LIST);
-			return new ColorCycle(cycleDurations, cycleColors);
-		default:
-			return null;
-		}
+                case COLOR_CYCLE:
+                        int[] durationsArray = intent.getIntArrayExtra(EXTRA_ANIMATION_DURATIONS);
+                        ArrayList<Integer> cycleDurations = new ArrayList<>();
+                        if (durationsArray != null) {
+                                for (int d : durationsArray) {
+                                        cycleDurations.add(d);
+                                }
+                        }
+                        int[] colorIdArray = intent.getIntArrayExtra(EXTRA_STORED_COLOR_IDS);
+                        ArrayList<StoredColor> storedColors = new ArrayList<>();
+                        if (colorIdArray != null) {
+                                for (int id : colorIdArray) {
+                                        storedColors.add(ColorRegistry.getInstance().getStoredColor(id));
+                                }
+                        }
+                        return new ColorCycle(cycleDurations, storedColors);
+                default:
+                        return null;
+                }
 	}
 
 	/**
@@ -299,13 +311,17 @@ public abstract class AnimationData implements Serializable {
 			final int cloudSaturation = PreferenceUtil.getIndexedSharedPreferenceInt(R.string.key_animation_cloud_saturation, colorId, 50);
 			ArrayList<Color> tileColors3 = PreferenceUtil.getIndexedSharedPreferenceColorList(R.string.key_animation_color_list, colorId);
 			return new TileChainClouds(duration, cloudSaturation, tileColors3, false);
-		case COLOR_CYCLE:
-			ArrayList<Integer> cycleDurations = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId);
-			ArrayList<Color> cycleColors = PreferenceUtil.getIndexedSharedPreferenceColorList(R.string.key_animation_color_list, colorId);
-			return new ColorCycle(cycleDurations, cycleColors);
-		default:
-			return null;
-		}
+                case COLOR_CYCLE:
+                        ArrayList<Integer> cycleDurations = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId);
+                        ArrayList<Integer> colorIds = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_color_list, colorId);
+                        ArrayList<StoredColor> storedColors = new ArrayList<>();
+                        for (int id : colorIds) {
+                                storedColors.add(ColorRegistry.getInstance().getStoredColor(id));
+                        }
+                        return new ColorCycle(cycleDurations, storedColors);
+                default:
+                        return null;
+                }
 	}
 
 	/**

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
@@ -313,16 +313,23 @@ public abstract class AnimationData implements Serializable {
 			return new TileChainClouds(duration, cloudSaturation, tileColors3, false);
                 case COLOR_CYCLE:
                         ArrayList<Integer> cycleDurations = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId);
-                        ArrayList<Integer> colorIds = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_color_list, colorId);
+                        ArrayList<Long> colorEntries = PreferenceUtil.getIndexedSharedPreferenceLongList(R.string.key_animation_color_list, colorId);
                         ArrayList<StoredColor> storedColors = new ArrayList<>();
-                        for (int id : colorIds) {
-                                storedColors.add(ColorRegistry.getInstance().getStoredColor(id));
+                        for (long entry : colorEntries) {
+                                if (entry >= Integer.MIN_VALUE && entry <= Integer.MAX_VALUE) {
+                                        StoredColor sc = ColorRegistry.getInstance().getStoredColor((int) entry);
+                                        if (sc != null) {
+                                                storedColors.add(sc);
+                                                continue;
+                                        }
+                                }
+                                storedColors.add(new StoredColor(new Color(entry), 0, null));
                         }
                         return new ColorCycle(cycleDurations, storedColors);
                 default:
                         return null;
                 }
-	}
+        }
 
 	/**
 	 * Store animation data within stored color.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -69,11 +69,11 @@ public class ColorCycle extends AnimationData {
 	public final void store(final int colorId) {
 		super.store(colorId);
                 PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId, mDurations);
-                ArrayList<Integer> colorIds = new ArrayList<>();
+                ArrayList<Long> colorEntries = new ArrayList<>();
                 for (StoredColor sc : mStoredColors) {
-                        colorIds.add(sc.getId());
+                        colorEntries.add((long) sc.getId());
                 }
-                PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_animation_color_list, colorId, colorIds);
+                PreferenceUtil.setIndexedSharedPreferenceLongList(R.string.key_animation_color_list, colorId, colorEntries);
         }
 
 	@Override

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -10,6 +10,9 @@ import java.util.List;
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.util.ColorUtil;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
+import de.jeisfeld.lifx.app.storedcolors.StoredColor;
+import de.jeisfeld.lifx.app.storedcolors.StoredMultizoneColors;
+import de.jeisfeld.lifx.app.storedcolors.StoredTileColors;
 import de.jeisfeld.lifx.lan.Light;
 import de.jeisfeld.lifx.lan.Light.AnimationDefinition;
 import de.jeisfeld.lifx.lan.MultiZoneLight;
@@ -31,21 +34,21 @@ public class ColorCycle extends AnimationData {
 	 * Durations for each color step in milliseconds.
 	 */
 	private final ArrayList<Integer> mDurations;
-	/**
-	 * Colors to cycle through.
-	 */
-	private final ArrayList<Color> mColors;
+        /**
+         * Stored colors to cycle through.
+         */
+        private final ArrayList<StoredColor> mStoredColors;
 
 	/**
 	 * Constructor.
 	 *
-	 * @param durations list of step durations
-	 * @param colors    list of colors to cycle
-	 */
-	public ColorCycle(final List<Integer> durations, final ArrayList<Color> colors) {
-		mDurations = new ArrayList<>(durations);
-		mColors = colors;
-	}
+         * @param durations   list of step durations
+         * @param storedColors list of stored colors to cycle
+         */
+        public ColorCycle(final List<Integer> durations, final ArrayList<StoredColor> storedColors) {
+                mDurations = new ArrayList<>(durations);
+                mStoredColors = storedColors;
+        }
 
 	@Override
 	public final void addToIntent(final Intent serviceIntent) {
@@ -54,16 +57,24 @@ public class ColorCycle extends AnimationData {
 		for (int i = 0; i < mDurations.size(); i++) {
 			durations[i] = mDurations.get(i);
 		}
-		serviceIntent.putExtra(EXTRA_ANIMATION_DURATIONS, durations);
-		serviceIntent.putExtra(EXTRA_COLOR_LIST, mColors);
-	}
+                serviceIntent.putExtra(EXTRA_ANIMATION_DURATIONS, durations);
+                int[] colorIds = new int[mStoredColors.size()];
+                for (int i = 0; i < mStoredColors.size(); i++) {
+                        colorIds[i] = mStoredColors.get(i).getId();
+                }
+                serviceIntent.putExtra(EXTRA_STORED_COLOR_IDS, colorIds);
+        }
 
 	@Override
 	public final void store(final int colorId) {
 		super.store(colorId);
-		PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId, mDurations);
-		PreferenceUtil.setIndexedSharedPreferenceColorList(R.string.key_animation_color_list, colorId, mColors);
-	}
+                PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId, mDurations);
+                ArrayList<Integer> colorIds = new ArrayList<>();
+                for (StoredColor sc : mStoredColors) {
+                        colorIds.add(sc.getId());
+                }
+                PreferenceUtil.setIndexedSharedPreferenceIntList(R.string.key_animation_color_list, colorId, colorIds);
+        }
 
 	@Override
 	protected final AnimationType getType() {
@@ -82,8 +93,12 @@ public class ColorCycle extends AnimationData {
 
                                @Override
                                public MultizoneColors getColors(final int n) {
-                                       return new MultizoneColors.Fixed(
-                                                       mColors.get(n % mColors.size()).withRelativeBrightness(brightness));
+                                       StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                       if (sc instanceof StoredMultizoneColors) {
+                                               return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
+                                       }
+                                       Color color = sc.getColor();
+                                       return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
                                }
                        };
                }
@@ -96,8 +111,12 @@ public class ColorCycle extends AnimationData {
 
                                @Override
                                public TileChainColors getColors(final int n) {
-                                       return new TileChainColors.Fixed(
-                                                       mColors.get(n % mColors.size()).withRelativeBrightness(brightness));
+                                       StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                       if (sc instanceof StoredTileColors) {
+                                               return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
+                                       }
+                                       Color color = sc.getColor();
+                                       return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
                                }
                        };
                }
@@ -109,34 +128,39 @@ public class ColorCycle extends AnimationData {
 
                        @Override
                        public Color getColor(final int n) {
-                               return mColors.get(n % mColors.size()).withRelativeBrightness(brightness);
+                               StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                               Color color = sc.getColor();
+                               return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
                        }
                };
        }
 
 	@Override
 	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {
-		ArrayList<Color> colors = new ArrayList<>();
-		for (Color c : mColors) {
-			colors.add(c.withRelativeBrightness(relativeBrightness));
-		}
-		return ColorUtil.getButtonDrawable(context, colors);
-	}
+                ArrayList<Color> colors = new ArrayList<>();
+                for (StoredColor sc : mStoredColors) {
+                        Color c = sc.getColor();
+                        if (c != null) {
+                                colors.add(c.withRelativeBrightness(relativeBrightness));
+                        }
+                }
+                return ColorUtil.getButtonDrawable(context, colors);
+        }
 
 	@Override
 	public final boolean isValid() {
-		if (mColors == null || mDurations == null) {
-			return false;
-		}
-		if (mColors.isEmpty() || mDurations.size() != mColors.size()) {
-			return false;
-		}
-		for (int d : mDurations) {
-			if (d <= 0) {
-				return false;
-			}
-		}
-		return true;
-	}
+                if (mStoredColors == null || mDurations == null) {
+                        return false;
+                }
+                if (mStoredColors.isEmpty() || mDurations.size() != mStoredColors.size()) {
+                        return false;
+                }
+                for (int d : mDurations) {
+                        if (d <= 0) {
+                                return false;
+                        }
+                }
+                return true;
+        }
 }
 

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -12,7 +12,11 @@ import de.jeisfeld.lifx.app.util.ColorUtil;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
 import de.jeisfeld.lifx.lan.Light;
 import de.jeisfeld.lifx.lan.Light.AnimationDefinition;
+import de.jeisfeld.lifx.lan.MultiZoneLight;
+import de.jeisfeld.lifx.lan.TileChain;
 import de.jeisfeld.lifx.lan.type.Color;
+import de.jeisfeld.lifx.lan.type.MultizoneColors;
+import de.jeisfeld.lifx.lan.type.TileChainColors;
 
 /**
  * Animation cycling through a sequence of colors with individual durations.
@@ -67,20 +71,48 @@ public class ColorCycle extends AnimationData {
 	}
 
 	@Override
-	protected final AnimationDefinition getAnimationDefinition(final Light light) {
-		final double brightness = getSelectedBrightness(light);
-		return new AnimationDefinition() {
-			@Override
-			public int getDuration(final int n) {
-				return mDurations.get(n % mDurations.size());
-			}
+       protected final AnimationDefinition getAnimationDefinition(final Light light) {
+               final double brightness = getSelectedBrightness(light);
+               if (light instanceof MultiZoneLight) {
+                       return new MultiZoneLight.AnimationDefinition() {
+                               @Override
+                               public int getDuration(final int n) {
+                                       return mDurations.get(n % mDurations.size());
+                               }
 
-			@Override
-			public Color getColor(final int n) {
-				return mColors.get(n % mColors.size()).withRelativeBrightness(brightness);
-			}
-		};
-	}
+                               @Override
+                               public MultizoneColors getColors(final int n) {
+                                       return new MultizoneColors.Fixed(
+                                                       mColors.get(n % mColors.size()).withRelativeBrightness(brightness));
+                               }
+                       };
+               }
+               if (light instanceof TileChain) {
+                       return new TileChain.AnimationDefinition() {
+                               @Override
+                               public int getDuration(final int n) {
+                                       return mDurations.get(n % mDurations.size());
+                               }
+
+                               @Override
+                               public TileChainColors getColors(final int n) {
+                                       return new TileChainColors.Fixed(
+                                                       mColors.get(n % mColors.size()).withRelativeBrightness(brightness));
+                               }
+                       };
+               }
+               return new AnimationDefinition() {
+                       @Override
+                       public int getDuration(final int n) {
+                               return mDurations.get(n % mDurations.size());
+                       }
+
+                       @Override
+                       public Color getColor(final int n) {
+                               return mColors.get(n % mColors.size()).withRelativeBrightness(brightness);
+                       }
+               };
+       }
 
 	@Override
 	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycleAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycleAnimationDialogFragment.java
@@ -30,7 +30,6 @@ import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoreColorTy
 import de.jeisfeld.lifx.app.storedcolors.StoredColorsDialogFragment.StoredColorsDialogListener;
 import de.jeisfeld.lifx.app.util.DialogUtil;
 import de.jeisfeld.lifx.app.util.DialogUtil.RequestDurationDialogFragment.RequestDurationDialogListener;
-import de.jeisfeld.lifx.lan.type.Color;
 
 /**
  * Dialog for setting up a color cycle animation using start and end times per step.
@@ -152,17 +151,13 @@ public class ColorCycleAnimationDialogFragment extends DialogFragment {
 					}
 				})
 				.setPositiveButton(R.string.button_start, (dialog, id) -> {
-					if (mListener != null && mListener.getValue() != null) {
-						ArrayList<Color> colors = new ArrayList<>();
-						for (StoredColor sc : mStoredColors) {
-							colors.add(sc.getColor());
-						}
-						mListener.getValue().onDialogPositiveClick(ColorCycleAnimationDialogFragment.this,
-								new ColorCycle(mDurations, colors));
-					}
-				});
-		return builder.create();
-	}
+                                        if (mListener != null && mListener.getValue() != null) {
+                                                mListener.getValue().onDialogPositiveClick(ColorCycleAnimationDialogFragment.this,
+                                                                new ColorCycle(mDurations, new ArrayList<>(mStoredColors)));
+                                        }
+                                });
+                return builder.create();
+        }
 
 	@Override
 	public final void onCancel(@Nonnull final DialogInterface dialogInterface) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/MultizoneAnimationDialogFragment.java
@@ -5,6 +5,8 @@ import android.app.Dialog;
 import android.content.DialogInterface;
 import android.os.Bundle;
 import android.view.View;
+import android.widget.AdapterView;
+import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.EditText;
 import android.widget.Spinner;
 
@@ -87,9 +89,25 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 		}
 
 		final View view = View.inflate(requireActivity(), R.layout.dialog_multizone_animation, null);
-		final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
-		final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
-		final Spinner spinnerDirection = view.findViewById(R.id.spinnerDirection);
+                final Spinner spinnerType = view.findViewById(R.id.spinnerType);
+                final EditText editTextDuration = view.findViewById(R.id.editTextDuration);
+                final EditText editTextStretch = view.findViewById(R.id.editTextStretch);
+
+                spinnerType.setOnItemSelectedListener(new OnItemSelectedListener() {
+                        @Override
+                        public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position,
+                                        final long id) {
+                                if (position >= MultizoneMoveDefinition.Direction.values().length) {
+                                        openColorCycleDialog();
+                                        dismiss();
+                                }
+                        }
+
+                        @Override
+                        public void onNothingSelected(final AdapterView<?> parent) {
+                                // do nothing
+                        }
+                });
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 		builder.setTitle(R.string.title_dialog_animation)
@@ -118,15 +136,53 @@ public class MultizoneAnimationDialogFragment extends DialogFragment {
 							stretch = 1;
 						}
 
-						MultizoneMoveDefinition.Direction direction =
-								MultizoneMoveDefinition.Direction.fromOrdinal(spinnerDirection.getSelectedItemPosition());
+                                                int position = spinnerType.getSelectedItemPosition();
+                                                if (position >= MultizoneMoveDefinition.Direction.values().length) {
+                                                        openColorCycleDialog();
+                                                }
+                                                else {
+                                                        MultizoneMoveDefinition.Direction direction =
+                                                                        MultizoneMoveDefinition.Direction.fromOrdinal(position);
 
-						mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
-								new MultizoneMove(duration, stretch, direction, mModel.getValue().getColors().getValue(), false));
-					}
-				});
-		return builder.create();
-	}
+                                                        mListener.getValue().onDialogPositiveClick(MultizoneAnimationDialogFragment.this,
+                                                                        new MultizoneMove(duration, stretch, direction,
+                                                                                        mModel.getValue().getColors().getValue(), false));
+                                                }
+                                        }
+                                });
+                return builder.create();
+        }
+
+        /**
+         * Open the color cycle animation dialog.
+         */
+        private void openColorCycleDialog() {
+               FragmentActivity activity = getActivity();
+               if (activity != null && mModel != null && mModel.getValue() != null) {
+                       Integer deviceId = mModel.getValue().getDeviceId();
+                       if (deviceId != null) {
+                               ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(activity, mModel.getValue(), deviceId,
+                                       new ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener() {
+                                               @Override
+                                               public void onDialogPositiveClick(final DialogFragment dialog,
+                                                               final AnimationData animationData) {
+                                                       if (mListener != null && mListener.getValue() != null) {
+                                                               mListener.getValue().onDialogPositiveClick(
+                                                                               MultizoneAnimationDialogFragment.this, animationData);
+                                                       }
+                                               }
+
+                                                @Override
+                                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogNegativeClick(
+                                                                                MultizoneAnimationDialogFragment.this);
+                                                        }
+                                                }
+                                       });
+                       }
+               }
+       }
 
 	@Override
 	public final void onCancel(@Nonnull final DialogInterface dialogInterface) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
@@ -117,16 +117,13 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 
 		if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
 				&& mModel.getValue().getLight().getProduct().isChain()) {
-			ArrayList<String> items = new ArrayList<>(Arrays.asList(
-					getResources().getStringArray(R.array.values_tilechain_animation_type)));
-			if (items.size() > TileChainAnimationType.CLOUDS.ordinal()) {
-				items.remove(TileChainAnimationType.CLOUDS.ordinal());
-			}
-			ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
-					android.R.layout.simple_spinner_item, items);
-			adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-			spinnerAnimationType.setAdapter(adapter);
-		}
+                        ArrayList<String> items = new ArrayList<>(Arrays.asList(
+                                        getResources().getStringArray(R.array.values_tilechain_animation_type)));
+                        ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
+                                        android.R.layout.simple_spinner_item, items);
+                        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                        spinnerAnimationType.setAdapter(adapter);
+                }
 
 		prepareSpinnerListener(parentView, spinnerAnimationType);
 
@@ -225,13 +222,16 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 								cloudSaturation = 50;
 							}
 							cloudSaturation = Math.max(0, Math.min(255, cloudSaturation));
-							mListener.getValue().onDialogPositiveClick(TileChainAnimationDialogFragment.this,
-									new TileChainClouds(duration * 5, cloudSaturation, mColors, false));
-							break;
-						case WAVE:
-						default:
-							double lightRadius =
-									Math.sqrt(light.getTotalHeight() * light.getTotalHeight() + light.getTotalWidth() * light.getTotalWidth()) / 2;
+                                                        mListener.getValue().onDialogPositiveClick(TileChainAnimationDialogFragment.this,
+                                                                        new TileChainClouds(duration * 5, cloudSaturation, mColors, false));
+                                                        break;
+                                                case COLOR_CYCLE:
+                                                        openColorCycleDialog();
+                                                        break;
+                                                case WAVE:
+                                                default:
+                                                        double lightRadius =
+                                                                        Math.sqrt(light.getTotalHeight() * light.getTotalHeight() + light.getTotalWidth() * light.getTotalWidth()) / 2;
 
 							double radius;
 							try {
@@ -262,8 +262,8 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 	 * @param parentView           The dialog parent view.
 	 * @param spinnerAnimationType The spinner.
 	 */
-	private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType) {
-		spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
+        private void prepareSpinnerListener(final View parentView, final Spinner spinnerAnimationType) {
+                spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position, final long id) {
 				TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(position);
@@ -308,25 +308,60 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 					ImageView imageViewColors = parentView.findViewById(R.id.imageViewColors);
 					imageViewColors.setImageDrawable(ColorUtil.getButtonDrawable(getContext(), mColors));
 					break;
-				case WAVE:
-				default:
-					parentView.findViewById(R.id.tableRowRadius).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowDirection).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowForm).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowColors).setVisibility(View.VISIBLE);
-					parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.GONE);
-					parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
-					break;
-				}
-			}
+                                case COLOR_CYCLE:
+                                        openColorCycleDialog();
+                                        dismiss();
+                                        break;
+                                case WAVE:
+                                default:
+                                        parentView.findViewById(R.id.tableRowRadius).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowDirection).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowForm).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowColors).setVisibility(View.VISIBLE);
+                                        parentView.findViewById(R.id.tableRowColorRegex).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowAdjustBrightness).setVisibility(View.GONE);
+                                        parentView.findViewById(R.id.tableRowCloudSaturation).setVisibility(View.GONE);
+                                        break;
+                                }
+                        }
 
 			@Override
 			public void onNothingSelected(final AdapterView<?> parent) {
 				// do nothing
-			}
-		});
-	}
+                        }
+                });
+        }
+
+        /**
+         * Open the color cycle animation dialog.
+         */
+        private void openColorCycleDialog() {
+               FragmentActivity activity = getActivity();
+               if (activity != null && mModel != null && mModel.getValue() != null) {
+                       Integer deviceId = mModel.getValue().getDeviceId();
+                       if (deviceId != null) {
+                               ColorCycleAnimationDialogFragment.displayColorCycleAnimationDialog(activity, mModel.getValue(), deviceId,
+                                       new ColorCycleAnimationDialogFragment.ColorCycleAnimationDialogListener() {
+                                               @Override
+                                               public void onDialogPositiveClick(final DialogFragment dialog,
+                                                               final AnimationData animationData) {
+                                                       if (mListener != null && mListener.getValue() != null) {
+                                                               mListener.getValue().onDialogPositiveClick(
+                                                                               TileChainAnimationDialogFragment.this, animationData);
+                                                       }
+                                               }
+
+                                                @Override
+                                                public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                        if (mListener != null && mListener.getValue() != null) {
+                                                                mListener.getValue().onDialogNegativeClick(
+                                                                                TileChainAnimationDialogFragment.this);
+                                                        }
+                                                }
+                                       });
+                       }
+               }
+       }
 
 	@Override
 	public final void onCancel(@Nonnull final DialogInterface dialogInterface) {
@@ -368,7 +403,11 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 		/**
 		 * Clouds.
 		 */
-		CLOUDS;
+                CLOUDS,
+                /**
+                 * Color cycle.
+                 */
+                COLOR_CYCLE;
 
 		/**
 		 * Get TileChainAnimationType from its ordinal value.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -58,15 +58,25 @@ public class LightViewModel extends DeviceViewModel {
 	 *
 	 * @return The light.
 	 */
-	protected Light getLight() {
-		return (Light) getDevice();
-	}
+        protected Light getLight() {
+                return (Light) getDevice();
+        }
 
-	/**
-	 * Get the animation status.
-	 *
-	 * @return The animation status.
-	 */
+       /**
+        * Get the device id.
+        *
+        * @return the device id or null if not available.
+        */
+       public Integer getDeviceId() {
+               Object deviceId = getLight().getParameter(DeviceRegistry.DEVICE_ID);
+               return deviceId instanceof Integer ? (Integer) deviceId : null;
+       }
+
+       /**
+        * Get the animation status.
+        *
+        * @return The animation status.
+        */
 	public LiveData<Boolean> getAnimationStatus() {
 		return mAnimationStatus;
 	}

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColor.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColor.java
@@ -7,6 +7,7 @@ import android.os.AsyncTask;
 import android.util.Log;
 
 import java.io.IOException;
+import java.io.Serializable;
 import java.lang.ref.WeakReference;
 import java.util.List;
 
@@ -29,7 +30,11 @@ import de.jeisfeld.lifx.lan.type.Power;
 /**
  * Class holding information about a stored color.
  */
-public class StoredColor {
+public class StoredColor implements Serializable {
+        /**
+         * The default serial version id.
+         */
+        private static final long serialVersionUID = 1L;
 	/**
 	 * The color.
 	 */

--- a/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
+++ b/LifxTools/app/src/main/res/layout/dialog_multizone_animation.xml
@@ -10,6 +10,21 @@
     <TableRow>
 
         <TextView
+            android:text="@string/label_animation_type"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <Spinner
+            android:id="@+id/spinnerType"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:entries="@array/values_multizone_animation_type"
+            android:minHeight="@dimen/medium_button_size"
+            android:spinnerMode="dropdown" />
+    </TableRow>
+
+    <TableRow>
+
+        <TextView
             android:text="@string/label_animation_duration"
             android:textAppearance="?android:attr/textAppearanceMedium" />
 
@@ -41,18 +56,4 @@
             tools:ignore="HardcodedText" />
     </TableRow>
 
-    <TableRow>
-
-        <TextView
-            android:text="@string/label_animation_direction"
-            android:textAppearance="?android:attr/textAppearanceMedium" />
-
-        <Spinner
-            android:id="@+id/spinnerDirection"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:entries="@array/values_multizone_animation_direction"
-            android:minHeight="@dimen/medium_button_size"
-            android:spinnerMode="dropdown" />
-    </TableRow>
 </TableLayout>

--- a/LifxTools/app/src/main/res/values-de/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-de/strings_dialog.xml
@@ -106,11 +106,12 @@
     <string name="label_minutes">Minuten</string>
     <string name="label_seconds">Sekunden</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>vorwärts</item>
         <item>rückwärts</item>
         <item>auswärts</item>
         <item>einwärts</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>Welle</item>
@@ -118,6 +119,7 @@
         <item>Flamme</item>
         <item>Metamorphose</item>
         <item>Wolken</item>
+        <item>Farbwechsel</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>auswärts</item>

--- a/LifxTools/app/src/main/res/values-es/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-es/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>adelante</item>
         <item>hacia atrás</item>
         <item>hacia fuera</item>
         <item>hacia adentro</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>ola</item>
@@ -117,6 +118,7 @@
         <item>fuego</item>
         <item>metamorfosis</item>
         <item>nubes</item>
+        <item>ciclo de color</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>hacia fuera</item>

--- a/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values-pt/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutos</string>
     <string name="label_seconds">Segundos</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>frente</item>
         <item>para trás</item>
         <item>para fora</item>
         <item>para dentro</item>
+        <item>ciclo de cor</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>onda</item>
@@ -117,6 +118,7 @@
         <item>chama</item>
         <item>metamorfose</item>
         <item>nuvens</item>
+        <item>ciclo de cor</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>para fora</item>

--- a/LifxTools/app/src/main/res/values/strings_dialog.xml
+++ b/LifxTools/app/src/main/res/values/strings_dialog.xml
@@ -105,11 +105,12 @@
     <string name="label_minutes">Minutes</string>
     <string name="label_seconds">Seconds</string>
 
-    <string-array name="values_multizone_animation_direction">
+    <string-array name="values_multizone_animation_type">
         <item>forward</item>
         <item>backward</item>
         <item>outward</item>
         <item>inward</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_type">
         <item>wave</item>
@@ -117,6 +118,7 @@
         <item>flame</item>
         <item>morph</item>
         <item>clouds</item>
+        <item>color cycle</item>
     </string-array>
     <string-array name="values_tilechain_animation_direction">
         <item>outward</item>


### PR DESCRIPTION
## Summary
- Add public device ID getter to light view models and refactor multizone and tile dialogs to use it for color cycle configuration
- Provide multi-zone and tile-chain aware animation definitions in `ColorCycle` to avoid class cast crashes
- Open color cycle dialog safely from multizone and tile-chain animation dialogs

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*
- `gradle test` *(fails: SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in your project's local properties file at '/workspace/LIFX/LifxTools/local.properties'.)*

------
https://chatgpt.com/codex/tasks/task_e_68c4a77a708883229478c3e1120e158e