### PR TITLE
fix: avoid infinite thread loop in animation service

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/LifxAnimationService.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/LifxAnimationService.java
@@ -189,29 +189,33 @@ public class LifxAnimationService extends Service {
 									updateOnEndAnimation(light.getTargetAddress(), wakeLock, animationData);
 								}
 							}
-							while (true) {
-								try {
-									//noinspection BusyWait
-									Thread.sleep(60000); // MAGIC_NUMBER
-								}
-								catch (InterruptedException e) {
-									try {
-										List<AnimationData> animationDataList = ANIMATED_LIGHT_DATA.get(mac);
-										if (animationDataList == null || animationDataList.size() < 2
-												|| !animationDataList.get(0).hasNativeImplementation(light)
-												|| !animationDataList.get(1).hasNativeImplementation(light)) {
-											// If there is another native animation in the queue, do not sent OFF
-											// as setEffect will not work shortly after OFF
-											animationData.getNativeAnimationDefinition(light).stopAnimation();
-										}
-									}
-									catch (IOException ex) {
-										// ignore
-									}
-									updateOnEndAnimation(light.getTargetAddress(), wakeLock, animationData);
-									return;
-								}
-							}
+                                                       // Sleep until the thread gets interrupted which signals the
+                                                       // animation should be stopped. Using isInterrupted avoids an
+                                                       // infinite loop in case the interrupt flag is already set
+                                                       // before entering the sleep call.
+                                                       while (!isInterrupted()) {
+                                                               try {
+                                                                       //noinspection BusyWait
+                                                                       Thread.sleep(60000); // MAGIC_NUMBER
+                                                               }
+                                                               catch (InterruptedException e) {
+                                                                       try {
+                                                                               List<AnimationData> animationDataList = ANIMATED_LIGHT_DATA.get(mac);
+                                                                               if (animationDataList == null || animationDataList.size() < 2
+                                                                                               || !animationDataList.get(0).hasNativeImplementation(light)
+                                                                                               || !animationDataList.get(1).hasNativeImplementation(light)) {
+                                                                                       // If there is another native animation in the queue, do not sent OFF
+                                                                                       // as setEffect will not work shortly after OFF
+                                                                                       animationData.getNativeAnimationDefinition(light).stopAnimation();
+                                                                               }
+                                                                       }
+                                                                       catch (IOException ex) {
+                                                                               // ignore
+                                                                       }
+                                                                       updateOnEndAnimation(light.getTargetAddress(), wakeLock, animationData);
+                                                                       return;
+                                                               }
+                                                       }
 						}
 					}.start();
 				}


### PR DESCRIPTION
## Summary
- exit native animation thread when interrupted to avoid infinite loop

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e499d6008322ab05b6f5c51b5e7b