### PR TITLE
Avoid recursive ColorRegistry calls when restoring animations

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/AnimationData.java
@@ -10,7 +10,6 @@ import java.util.ArrayList;
 
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
-import de.jeisfeld.lifx.app.storedcolors.ColorRegistry;
 import de.jeisfeld.lifx.app.storedcolors.StoredColor;
 import de.jeisfeld.lifx.app.storedcolors.StoredMultizoneColors;
 import de.jeisfeld.lifx.app.util.PreferenceUtil;
@@ -249,17 +248,17 @@ public abstract class AnimationData implements Serializable {
 					cycleDurations.add(d);
 				}
 			}
-			int[] colorIdArray = intent.getIntArrayExtra(EXTRA_STORED_COLOR_IDS);
-			ArrayList<StoredColor> storedColors = new ArrayList<>();
-			if (colorIdArray != null) {
-				for (int id : colorIdArray) {
-					storedColors.add(ColorRegistry.getInstance().getStoredColor(id));
-				}
-			}
-			return new ColorCycle(cycleDurations, storedColors);
-		default:
-			return null;
-		}
+                        int[] colorIdArray = intent.getIntArrayExtra(EXTRA_STORED_COLOR_IDS);
+                        ArrayList<StoredColor> storedColors = new ArrayList<>();
+                        if (colorIdArray != null) {
+                                for (int id : colorIdArray) {
+                                        storedColors.add(StoredColor.fromId(id));
+                                }
+                        }
+                        return new ColorCycle(cycleDurations, storedColors);
+                default:
+                        return null;
+                }
 	}
 
 	/**
@@ -313,22 +312,21 @@ public abstract class AnimationData implements Serializable {
 			return new TileChainClouds(duration, cloudSaturation, tileColors3, false);
 		case COLOR_CYCLE:
 			ArrayList<Integer> cycleDurations = PreferenceUtil.getIndexedSharedPreferenceIntList(R.string.key_animation_durations_list, colorId);
-			ArrayList<Long> colorEntries = PreferenceUtil.getIndexedSharedPreferenceLongList(R.string.key_animation_color_list, colorId);
-			ArrayList<StoredColor> storedColors = new ArrayList<>();
-			for (long entry : colorEntries) {
-				if (entry >= Integer.MIN_VALUE && entry <= Integer.MAX_VALUE) {
-					StoredColor sc = ColorRegistry.getInstance().getStoredColor((int) entry);
-					if (sc != null) {
-						storedColors.add(sc);
-						continue;
-					}
-				}
-				storedColors.add(new StoredColor(new Color(entry), 0, null));
-			}
-			return new ColorCycle(cycleDurations, storedColors);
-		default:
-			return null;
-		}
+                        ArrayList<Long> colorEntries = PreferenceUtil.getIndexedSharedPreferenceLongList(R.string.key_animation_color_list, colorId);
+                        ArrayList<StoredColor> storedColors = new ArrayList<>();
+                        for (long entry : colorEntries) {
+                                if (entry >= Integer.MIN_VALUE && entry <= Integer.MAX_VALUE
+                                                && PreferenceUtil.hasIndexedSharedPreference(R.string.key_color_name, (int) entry)) {
+                                        storedColors.add(StoredColor.fromId((int) entry));
+                                }
+                                else {
+                                        storedColors.add(new StoredColor(new Color(entry), 0, null));
+                                }
+                        }
+                        return new ColorCycle(cycleDurations, storedColors);
+                default:
+                        return null;
+                }
 	}
 
 	/**


### PR DESCRIPTION
## Summary
- prevent `AnimationData.fromStoredAnimation` from triggering recursive `ColorRegistry` initialization by using `StoredColor.fromId` and checking shared preferences directly
- simplify `AnimationData.fromIntent` to reconstruct stored colors without `ColorRegistry`

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5e791df7c8322a9da658f908c72a5