### PR TITLE
Fix renaming of stored animations

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredAnimation.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredAnimation.java
@@ -111,14 +111,14 @@ public class StoredAnimation extends StoredColor {
 		return mAnimationData;
 	}
 
-	/**
-	 * Get the relative brightness.
-	 *
-	 * @return The relative brightness.
-	 */
-	private double getRelativeBrightness() {
-		return mRelativeBrightness;
-	}
+        /**
+         * Get the relative brightness.
+         *
+         * @return The relative brightness.
+         */
+        public double getRelativeBrightness() {
+                return mRelativeBrightness;
+        }
 
 	@NonNull
 	@Override

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColorsViewAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/storedcolors/StoredColorsViewAdapter.java
@@ -98,18 +98,23 @@ public class StoredColorsViewAdapter extends RecyclerView.Adapter<StoredColorsVi
 								}
 								else {
 									StoredColor newColor;
-									if (storedColor instanceof StoredMultizoneColors) {
-										newColor = new StoredMultizoneColors(storedColor.getId(), ((StoredMultizoneColors) storedColor).getColors(),
-												storedColor.getDeviceId(), text.trim());
-									}
-									else if (storedColor instanceof StoredTileColors) {
-										newColor = new StoredTileColors(storedColor.getId(), ((StoredTileColors) storedColor).getColors(),
-												storedColor.getDeviceId(), text.trim());
-									}
-									else {
-										newColor = new StoredColor(storedColor.getId(), storedColor.getColor(),
-												storedColor.getDeviceId(), text.trim());
-									}
+                                                                        if (storedColor instanceof StoredMultizoneColors) {
+                                                                                newColor = new StoredMultizoneColors(storedColor.getId(), ((StoredMultizoneColors) storedColor).getColors(),
+                                                                                                storedColor.getDeviceId(), text.trim());
+                                                                        }
+                                                                        else if (storedColor instanceof StoredTileColors) {
+                                                                                newColor = new StoredTileColors(storedColor.getId(), ((StoredTileColors) storedColor).getColors(),
+                                                                                                storedColor.getDeviceId(), text.trim());
+                                                                        }
+                                                                        else if (storedColor instanceof StoredAnimation) {
+                                                                                StoredAnimation storedAnimation = (StoredAnimation) storedColor;
+                                                                                newColor = new StoredAnimation(storedAnimation.getId(), storedAnimation.getAnimationData(),
+                                                                                                storedAnimation.getRelativeBrightness(), storedAnimation.getDeviceId(), text.trim());
+                                                                        }
+                                                                        else {
+                                                                                newColor = new StoredColor(storedColor.getId(), storedColor.getColor(),
+                                                                                                storedColor.getDeviceId(), text.trim());
+                                                                        }
 
 									ColorRegistry.getInstance().addOrUpdate(newColor);
 									mStoredColors.set(position, newColor);


### PR DESCRIPTION
## Summary
- handle renaming stored animations by reconstructing `StoredAnimation` objects instead of plain `StoredColor`
- expose `StoredAnimation.getRelativeBrightness()` for reuse

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5eb56bd3483229702b3f4e1877ac7