### PR TITLE
Fix tile chain animation options and color cycle handling

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -83,56 +83,55 @@ public class ColorCycle extends AnimationData {
 
 	@Override
 	protected final AnimationDefinition getAnimationDefinition(final Light light) {
-		final double brightness = getSelectedBrightness(light);
-		if (light instanceof MultiZoneLight) {
-			return new MultiZoneLight.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+                if (light instanceof MultiZoneLight) {
+                        return new MultiZoneLight.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public MultizoneColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredMultizoneColors) {
-						return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		if (light instanceof TileChain) {
-			return new TileChain.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+                                @Override
+                                public MultizoneColors getColors(final int n) {
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredMultizoneColors) {
+                                                return ((StoredMultizoneColors) sc).getColors();
+                                        }
+                                        Color color = sc.getColor();
+                                        return new MultizoneColors.Fixed(color == null ? Color.OFF : color);
+                                }
+                        };
+                }
+                if (light instanceof TileChain) {
+                        return new TileChain.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public TileChainColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredTileColors) {
-						return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		return new AnimationDefinition() {
-			@Override
-			public int getDuration(final int n) {
-				return mDurations.get(n % mDurations.size());
-			}
+                                @Override
+                                public TileChainColors getColors(final int n) {
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredTileColors) {
+                                                return ((StoredTileColors) sc).getColors();
+                                        }
+                                        Color color = sc.getColor();
+                                        return new TileChainColors.Fixed(color == null ? Color.OFF : color);
+                                }
+                        };
+                }
+                return new AnimationDefinition() {
+                        @Override
+                        public int getDuration(final int n) {
+                                return mDurations.get(n % mDurations.size());
+                        }
 
-			@Override
-			public Color getColor(final int n) {
-				StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-				Color color = sc.getColor();
-				return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
-			}
-		};
+                        @Override
+                        public Color getColor(final int n) {
+                                StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                Color color = sc.getColor();
+                                return color == null ? Color.OFF : color;
+                        }
+                };
 	}
 
 	@Override

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycleAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycleAnimationDialogFragment.java
@@ -251,22 +251,26 @@ public class ColorCycleAnimationDialogFragment extends DialogFragment {
 				});
 			}
 
-			textViewEnd.setOnClickListener(v -> {
-				final int endSeconds = end / (int) TimeUnit.SECONDS.toMillis(1);
-				DialogUtil.displayDurationDialog(requireActivity(), new RequestDurationDialogListener() {
-							@Override
-							public void onDialogPositiveClick(final DialogFragment dialog, final int minutes, final int seconds) {
-								int newEnd = (int) (TimeUnit.MINUTES.toMillis(minutes) + TimeUnit.SECONDS.toMillis(seconds));
-								mDurations.set(position, newEnd - start);
-								notifyDataSetChanged();
-							}
+                        textViewEnd.setOnClickListener(v -> {
+                                final int durationSeconds = mDurations.get(position)
+                                                / (int) TimeUnit.SECONDS.toMillis(1);
+                                DialogUtil.displayDurationDialog(requireActivity(), new RequestDurationDialogListener() {
+                                                        @Override
+                                                        public void onDialogPositiveClick(final DialogFragment dialog,
+                                                                        final int minutes, final int seconds) {
+                                                                int newDuration = (int) (TimeUnit.MINUTES.toMillis(minutes)
+                                                                                                + TimeUnit.SECONDS.toMillis(seconds));
+                                                                mDurations.set(position, newDuration);
+                                                                notifyDataSetChanged();
+                                                        }
 
-							@Override
-							public void onDialogNegativeClick(final DialogFragment dialog) {
-							}
-						}, R.string.title_dialog_scene_step_duration, R.string.button_ok,
-						endSeconds / 60, endSeconds % 60, R.string.message_dialog_scene_step_duration);
-			});
+                                                        @Override
+                                                        public void onDialogNegativeClick(final DialogFragment dialog) {
+                                                        }
+                                                }, R.string.title_dialog_scene_step_duration, R.string.button_ok,
+                                                durationSeconds / 60, durationSeconds % 60,
+                                                R.string.message_dialog_scene_step_duration);
+                        });
 
 			view.findViewById(R.id.imageViewDelete).setOnClickListener(v -> {
 				mDurations.remove(position);

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/TileChainAnimationDialogFragment.java
@@ -42,10 +42,15 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 	 * Instance state flag indicating if a dialog should not be recreated after orientation change.
 	 */
 	private static final String PREVENT_RECREATION = "preventRecreation";
-	/**
-	 * The selected colors.
-	 */
-	private ArrayList<Color> mColors = new ArrayList<>();
+        /**
+         * The selected colors.
+         */
+        private ArrayList<Color> mColors = new ArrayList<>();
+
+        /**
+         * The animation types displayed in the spinner.
+         */
+        private ArrayList<TileChainAnimationType> mAnimationTypes = new ArrayList<>();
 
 	/**
 	 * Display a dialog for setting up a multizone animation.
@@ -104,8 +109,8 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 			dismiss();
 		}
 
-		final View parentView = View.inflate(requireActivity(), R.layout.dialog_tilechain_animation, null);
-		final Spinner spinnerAnimationType = parentView.findViewById(R.id.spinnerAnimationType);
+                final View parentView = View.inflate(requireActivity(), R.layout.dialog_tilechain_animation, null);
+                final Spinner spinnerAnimationType = parentView.findViewById(R.id.spinnerAnimationType);
 		final EditText editTextDuration = parentView.findViewById(R.id.editTextDuration);
 		final EditText editTextRadius = parentView.findViewById(R.id.editTextRadius);
 		final Spinner spinnerDirection = parentView.findViewById(R.id.spinnerDirection);
@@ -115,15 +120,20 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 		final EditText editTextCloudSaturation = parentView.findViewById(R.id.editTextCloudSaturation);
 		final ImageView imageViewColors = parentView.findViewById(R.id.imageViewColors);
 
-		if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
-				&& mModel.getValue().getLight().getProduct().isChain()) {
-			ArrayList<String> items = new ArrayList<>(Arrays.asList(
-					getResources().getStringArray(R.array.values_tilechain_animation_type)));
-			ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
-					android.R.layout.simple_spinner_item, items);
-			adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-			spinnerAnimationType.setAdapter(adapter);
-		}
+                final String[] typeValues = getResources().getStringArray(R.array.values_tilechain_animation_type);
+                mAnimationTypes = new ArrayList<>(Arrays.asList(TileChainAnimationType.values()));
+                if (mModel != null && mModel.getValue() != null && mModel.getValue().getLight() != null
+                                && mModel.getValue().getLight().getProduct().isChain()) {
+                        mAnimationTypes.remove(TileChainAnimationType.CLOUDS);
+                        ArrayList<String> items = new ArrayList<>();
+                        for (TileChainAnimationType type : mAnimationTypes) {
+                                items.add(typeValues[type.ordinal()]);
+                        }
+                        ArrayAdapter<String> adapter = new ArrayAdapter<>(requireActivity(),
+                                        android.R.layout.simple_spinner_item, items);
+                        adapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+                        spinnerAnimationType.setAdapter(adapter);
+                }
 
 		prepareSpinnerListener(parentView, spinnerAnimationType);
 
@@ -136,7 +146,8 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 			if (getActivity() == null) {
 				return;
 			}
-			TileChainAnimationType selectedType = TileChainAnimationType.fromOrdinal(spinnerAnimationType.getSelectedItemPosition());
+                        TileChainAnimationType selectedType = mAnimationTypes
+                                        .get(spinnerAnimationType.getSelectedItemPosition());
 			if (selectedType == TileChainAnimationType.CLOUDS) {
 				Color initialColor = mColors.isEmpty() ? Color.CYAN : mColors.get(0);
 				Builder builder = new Builder(getContext(), R.layout.dialog_colorpicker);
@@ -187,7 +198,8 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 					if (mListener != null && mListener.getValue() != null && mModel != null // BOOLEAN_EXPRESSION_COMPLEXITY
 							&& mModel.getValue() != null && mModel.getValue().getLight() != null) {
 						TileChain light = mModel.getValue().getLight();
-						TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(spinnerAnimationType.getSelectedItemPosition());
+                                                TileChainAnimationType animationType = mAnimationTypes
+                                                                .get(spinnerAnimationType.getSelectedItemPosition());
 
 						int duration;
 						try {
@@ -266,7 +278,7 @@ public class TileChainAnimationDialogFragment extends DialogFragment {
 		spinnerAnimationType.setOnItemSelectedListener(new OnItemSelectedListener() {
 			@Override
 			public void onItemSelected(final AdapterView<?> parent, final View selectedView, final int position, final long id) {
-				TileChainAnimationType animationType = TileChainAnimationType.fromOrdinal(position);
+                                TileChainAnimationType animationType = mAnimationTypes.get(position);
 				switch (animationType) {
 				case IMAGE_TRANSITION:
 					parentView.findViewById(R.id.tableRowRadius).setVisibility(View.GONE);


### PR DESCRIPTION
## Summary
- Remove clouds option when animating a tile chain device
- Show step duration instead of end time in color cycle editor
- Prevent initial brightness jump when starting color cycle animations

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5ee62b4148322942b32328151b335