### PR TITLE
Avoid initial color jump in color cycle animation

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -77,63 +77,76 @@ public class ColorCycle extends AnimationData {
 	}
 
 	@Override
-	protected final AnimationType getType() {
-		return AnimationType.COLOR_CYCLE;
-	}
+        protected final AnimationType getType() {
+                return AnimationType.COLOR_CYCLE;
+        }
 
-	@Override
-	protected final AnimationDefinition getAnimationDefinition(final Light light) {
-		final double brightness = getSelectedBrightness(light);
-		if (light instanceof MultiZoneLight) {
-			return new MultiZoneLight.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+        @Override
+        protected final AnimationDefinition getAnimationDefinition(final Light light) {
+                final double brightness = getSelectedBrightness(light);
+                if (light instanceof MultiZoneLight) {
+                        final List<Color> startColorList = ((MultiZoneLight) light).getColors();
+                        final MultizoneColors startColors = startColorList == null ? null : new MultizoneColors.Exact(startColorList);
+                        return new MultiZoneLight.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public MultizoneColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredMultizoneColors) {
-						return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		if (light instanceof TileChain) {
-			return new TileChain.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+                                @Override
+                                public MultizoneColors getColors(final int n) {
+                                        if (n == 0 && startColors != null) {
+                                                return startColors;
+                                        }
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredMultizoneColors) {
+                                                return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
+                                        }
+                                        Color color = sc.getColor();
+                                        return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
+                                }
+                        };
+                }
+                if (light instanceof TileChain) {
+                        final TileChainColors startColors = ((TileChain) light).getColors();
+                        return new TileChain.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public TileChainColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredTileColors) {
-						return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		return new AnimationDefinition() {
-			@Override
-			public int getDuration(final int n) {
-				return mDurations.get(n % mDurations.size());
-			}
+                                @Override
+                                public TileChainColors getColors(final int n) {
+                                        if (n == 0 && startColors != null) {
+                                                return startColors;
+                                        }
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredTileColors) {
+                                                return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
+                                        }
+                                        Color color = sc.getColor();
+                                        return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
+                                }
+                        };
+                }
+                final Color startColor = light.getColor();
+                return new AnimationDefinition() {
+                        @Override
+                        public int getDuration(final int n) {
+                                return mDurations.get(n % mDurations.size());
+                        }
 
-			@Override
-			public Color getColor(final int n) {
-				StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-				Color color = sc.getColor();
-				return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
-			}
-		};
-	}
+                        @Override
+                        public Color getColor(final int n) {
+                                if (n == 0 && startColor != null) {
+                                        return startColor;
+                                }
+                                StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                Color color = sc.getColor();
+                                return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
+                        }
+                };
+        }
 
 	@Override
 	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {


### PR DESCRIPTION
## Summary
- Prevent color cycle animations from starting with a brightness-based color change by reusing the light's current colors for the first animation step.

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f1f2367883228cbbf52c26bd7040