### PR TITLE
Avoid brightness jump when starting color cycle animation

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -81,59 +81,58 @@ public class ColorCycle extends AnimationData {
 		return AnimationType.COLOR_CYCLE;
 	}
 
-	@Override
-	protected final AnimationDefinition getAnimationDefinition(final Light light) {
-		final double brightness = getSelectedBrightness(light);
-		if (light instanceof MultiZoneLight) {
-			return new MultiZoneLight.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+        @Override
+        protected final AnimationDefinition getAnimationDefinition(final Light light) {
+                if (light instanceof MultiZoneLight) {
+                        return new MultiZoneLight.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public MultizoneColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredMultizoneColors) {
-						return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		if (light instanceof TileChain) {
-			return new TileChain.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+                                @Override
+                                public MultizoneColors getColors(final int n) {
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredMultizoneColors) {
+                                                return ((StoredMultizoneColors) sc).getColors();
+                                        }
+                                        Color color = sc.getColor();
+                                        return new MultizoneColors.Fixed(color == null ? Color.OFF : color);
+                                }
+                        };
+                }
+                if (light instanceof TileChain) {
+                        return new TileChain.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public TileChainColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredTileColors) {
-						return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		return new AnimationDefinition() {
-			@Override
-			public int getDuration(final int n) {
-				return mDurations.get(n % mDurations.size());
-			}
+                                @Override
+                                public TileChainColors getColors(final int n) {
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredTileColors) {
+                                                return ((StoredTileColors) sc).getColors();
+                                        }
+                                        Color color = sc.getColor();
+                                        return new TileChainColors.Fixed(color == null ? Color.OFF : color);
+                                }
+                        };
+                }
+                return new AnimationDefinition() {
+                        @Override
+                        public int getDuration(final int n) {
+                                return mDurations.get(n % mDurations.size());
+                        }
 
-			@Override
-			public Color getColor(final int n) {
-				StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-				Color color = sc.getColor();
-				return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
-			}
-		};
-	}
+                        @Override
+                        public Color getColor(final int n) {
+                                StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                Color color = sc.getColor();
+                                return color == null ? Color.OFF : color;
+                        }
+                };
+        }
 
 	@Override
 	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -14,6 +14,7 @@ import androidx.lifecycle.MutableLiveData;
 import de.jeisfeld.lifx.app.Application;
 import de.jeisfeld.lifx.app.R;
 import de.jeisfeld.lifx.app.animation.AnimationData;
+import de.jeisfeld.lifx.app.animation.ColorCycle;
 import de.jeisfeld.lifx.app.animation.LifxAnimationService;
 import de.jeisfeld.lifx.app.animation.LifxAnimationService.AnimationStatus;
 import de.jeisfeld.lifx.app.managedevices.DeviceRegistry;
@@ -238,26 +239,29 @@ public class LightViewModel extends DeviceViewModel {
 				return null;
 			}
 			Light light = model.getLight();
-			double brightness = AnimationData.getSelectedBrightness(light);
-			model.updateSelectedBrightness(brightness);
-			Color currentColor = model.mColor.getValue();
-			if (currentColor != null) {
-				Color newColor = currentColor.withBrightness(brightness);
-				try {
-					if (model.mPower.getValue() != null && model.mPower.getValue().isOff() && isAutoOn()) {
-						light.setColor(newColor, 0, false);
-						light.setPower(true, 0, false);
-						model.updatePowerButton(Power.ON);
-					}
-					else {
-						light.setColor(newColor, 0, false);
-					}
-					model.updateStoredColor(newColor);
-				}
-				catch (IOException e) {
-					Log.w(Application.TAG, e);
-				}
-			}
+                        double brightness = AnimationData.getSelectedBrightness(light);
+                        model.updateSelectedBrightness(brightness);
+                        Color currentColor = model.mColor.getValue();
+                        if (currentColor != null) {
+                                Color newColor = currentColor;
+                                if (!(mAnimationData instanceof ColorCycle)) {
+                                        newColor = newColor.withBrightness(brightness);
+                                }
+                                try {
+                                        if (model.mPower.getValue() != null && model.mPower.getValue().isOff() && isAutoOn()) {
+                                                light.setColor(newColor, 0, false);
+                                                light.setPower(true, 0, false);
+                                                model.updatePowerButton(Power.ON);
+                                        }
+                                        else {
+                                                light.setColor(newColor, 0, false);
+                                        }
+                                        model.updateStoredColor(newColor);
+                                }
+                                catch (IOException e) {
+                                        Log.w(Application.TAG, e);
+                                }
+                        }
 			LifxAnimationService.triggerAnimationService(mContext, light, mAnimationData);
 			return null;
 		}


### PR DESCRIPTION
## Summary
- Preserve current brightness when starting Color Cycle animations
- Generate Color Cycle steps without altering brightness

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f1f2367883228cbbf52c26bd7040