### PR TITLE
Fix brightness behavior for animations and group updates

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/animation/ColorCycle.java
@@ -82,58 +82,60 @@ public class ColorCycle extends AnimationData {
 	}
 
 	@Override
-	protected final AnimationDefinition getAnimationDefinition(final Light light) {
-		final double brightness = getSelectedBrightness(light);
-		if (light instanceof MultiZoneLight) {
-			return new MultiZoneLight.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+        protected final AnimationDefinition getAnimationDefinition(final Light light) {
+                if (light instanceof MultiZoneLight) {
+                        return new MultiZoneLight.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public MultizoneColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredMultizoneColors) {
-						return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		if (light instanceof TileChain) {
-			return new TileChain.AnimationDefinition() {
-				@Override
-				public int getDuration(final int n) {
-					return mDurations.get(n % mDurations.size());
-				}
+                                @Override
+                                public MultizoneColors getColors(final int n) {
+                                        double brightness = getSelectedBrightness(light);
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredMultizoneColors) {
+                                                return ((StoredMultizoneColors) sc).getColors().withRelativeBrightness(brightness);
+                                        }
+                                        Color color = sc.getColor();
+                                        return new MultizoneColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
+                                }
+                        };
+                }
+                if (light instanceof TileChain) {
+                        return new TileChain.AnimationDefinition() {
+                                @Override
+                                public int getDuration(final int n) {
+                                        return mDurations.get(n % mDurations.size());
+                                }
 
-				@Override
-				public TileChainColors getColors(final int n) {
-					StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-					if (sc instanceof StoredTileColors) {
-						return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
-					}
-					Color color = sc.getColor();
-					return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
-				}
-			};
-		}
-		return new AnimationDefinition() {
-			@Override
-			public int getDuration(final int n) {
-				return mDurations.get(n % mDurations.size());
-			}
+                                @Override
+                                public TileChainColors getColors(final int n) {
+                                        double brightness = getSelectedBrightness(light);
+                                        StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                        if (sc instanceof StoredTileColors) {
+                                                return ((StoredTileColors) sc).getColors().withRelativeBrightness(brightness);
+                                        }
+                                        Color color = sc.getColor();
+                                        return new TileChainColors.Fixed(color == null ? Color.OFF : color.withRelativeBrightness(brightness));
+                                }
+                        };
+                }
+                return new AnimationDefinition() {
+                        @Override
+                        public int getDuration(final int n) {
+                                return mDurations.get(n % mDurations.size());
+                        }
 
-			@Override
-			public Color getColor(final int n) {
-				StoredColor sc = mStoredColors.get(n % mStoredColors.size());
-				Color color = sc.getColor();
-				return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
-			}
-		};
-	}
+                        @Override
+                        public Color getColor(final int n) {
+                                double brightness = getSelectedBrightness(light);
+                                StoredColor sc = mStoredColors.get(n % mStoredColors.size());
+                                Color color = sc.getColor();
+                                return color == null ? Color.OFF : color.withRelativeBrightness(brightness);
+                        }
+                };
+        }
 
 	@Override
 	public final Drawable getBaseButtonDrawable(final Context context, final Light light, final double relativeBrightness) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
@@ -231,6 +231,42 @@ public class DeviceAdapter extends BaseAdapter {
                 }
         }
 
+        /**
+         * Refresh the brightness for all devices of a group after setting group brightness.
+         *
+         * @param groupId   The group id.
+         * @param brightness The brightness.
+         */
+        protected void refreshGroupBrightness(final int groupId, final double brightness) {
+                for (MainViewModel model : mViewModels) {
+                        if (model instanceof LightViewModel) {
+                                Light light = ((LightViewModel) model).getLight();
+                                if (light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) != null
+                                                && (int) light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) == groupId) {
+                                        try {
+                                                if (model instanceof MultizoneViewModel) {
+                                                        ((MultizoneViewModel) model).updateSelectedBrightness(brightness);
+                                                }
+                                                else if (model instanceof TileViewModel) {
+                                                        ((TileViewModel) model).updateSelectedBrightness(brightness);
+                                                }
+                                                else {
+                                                        ((LightViewModel) model).updateSelectedBrightness(brightness);
+                                                        Color color = ((LightViewModel) model).getColor().getValue();
+                                                        if (color != null) {
+                                                                ((LightViewModel) model).updateStoredColor(
+                                                                                color.withRelativeBrightness(brightness));
+                                                        }
+                                                }
+                                        }
+                                        catch (Exception e) {
+                                                // ignore NullPointerException in case of call before instantiation
+                                        }
+                                }
+                        }
+                }
+        }
+
 	/**
 	 * Refresh the power for all devices of a group after setting group power.
 	 *

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/DeviceAdapter.java
@@ -211,22 +211,25 @@ public class DeviceAdapter extends BaseAdapter {
 	 * @param groupId The group id.
 	 * @param color   The color.
 	 */
-	protected void refreshGroupColor(final int groupId, final Color color) {
-		for (MainViewModel model : mViewModels) {
-			if (model instanceof LightViewModel) {
-				Light light = ((LightViewModel) model).getLight();
-				if (light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) != null
-						&& (int) light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) == groupId) {
-					try {
-						((LightViewModel) model).updateStoredColor(color);
-					}
-					catch (Exception e) {
-						// ignore NullPointerException in case of call before instantiation
-					}
-				}
-			}
-		}
-	}
+        protected void refreshGroupColor(final int groupId, final Color color) {
+                if (color == null) {
+                        return;
+                }
+                for (MainViewModel model : mViewModels) {
+                        if (model instanceof LightViewModel) {
+                                Light light = ((LightViewModel) model).getLight();
+                                if (light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) != null
+                                                && (int) light.getParameter(DeviceRegistry.DEVICE_GROUP_ID) == groupId) {
+                                        try {
+                                                ((LightViewModel) model).updateStoredColor(color);
+                                        }
+                                        catch (Exception e) {
+                                                // ignore NullPointerException in case of call before instantiation
+                                        }
+                                }
+                        }
+                }
+        }
 
 	/**
 	 * Refresh the power for all devices of a group after setting group power.

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/GroupViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/GroupViewModel.java
@@ -22,8 +22,10 @@ import de.jeisfeld.lifx.app.util.PreferenceUtil;
 import de.jeisfeld.lifx.lan.Device;
 import de.jeisfeld.lifx.lan.Group;
 import de.jeisfeld.lifx.lan.Light;
+import de.jeisfeld.lifx.lan.TileChain;
 import de.jeisfeld.lifx.lan.type.Color;
 import de.jeisfeld.lifx.lan.type.Power;
+import de.jeisfeld.lifx.lan.type.TileChainColors;
 
 /**
  * Class holding data for the display view of a group.
@@ -118,13 +120,17 @@ public class GroupViewModel extends MainViewModel {
 		new CheckColorTask(this).executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR);
 	}
 
-	@Override
-	protected final void updateBrightness(final double brightness) {
-		synchronized (mRunningSetColorTasks) {
-			for (Device device : DeviceRegistry.getInstance().getDevices(mGroupId, false)) {
-				if (device instanceof Light) {
-					List<AsyncExecutable> tasksForDevice = mRunningSetColorTasks.computeIfAbsent(device, k -> new ArrayList<>());
-					tasksForDevice.add(new SetColorTask(this, brightness, (Light) device));
+        @Override
+        protected final void updateBrightness(final double brightness) {
+                DeviceAdapter adapter = mAdapter.get();
+                if (adapter != null) {
+                        adapter.refreshGroupBrightness(mGroupId, brightness);
+                }
+                synchronized (mRunningSetColorTasks) {
+                        for (Device device : DeviceRegistry.getInstance().getDevices(mGroupId, false)) {
+                                if (device instanceof Light) {
+                                        List<AsyncExecutable> tasksForDevice = mRunningSetColorTasks.computeIfAbsent(device, k -> new ArrayList<>());
+                                        tasksForDevice.add(new SetColorTask(this, brightness, (Light) device));
 
 					if (tasksForDevice.size() > 2) {
 						tasksForDevice.remove(1);
@@ -381,15 +387,35 @@ public class GroupViewModel extends MainViewModel {
 			mBrightness = brightness;
 		}
 
-		@Override
-		protected Color doInBackground(final Color... colors) {
-			try {
-				if (mColor == null) {
-					mLight.setBrightness(mBrightness);
-				}
-				else {
-					mLight.setColor(mColor, 0, false);
-				}
+                @Override
+                protected Color doInBackground(final Color... colors) {
+                        try {
+                                if (mColor == null) {
+                                        if (mLight instanceof TileChain) {
+                                                TileChain tileChain = (TileChain) mLight;
+                                                TileChainColors colors = tileChain.getColors();
+                                                if (colors != null) {
+                                                        int maxBrightness = colors.getMaxBrightness(tileChain);
+                                                        if (maxBrightness > 0) {
+                                                                double relative = maxBrightness / 65535.0; // MAGIC_NUMBER
+                                                                TileChainColors baseColors = colors.withRelativeBrightness(1 / relative);
+                                                                tileChain.setColors(baseColors.withRelativeBrightness(mBrightness), 0, false);
+                                                        }
+                                                        else {
+                                                                tileChain.setBrightness(mBrightness);
+                                                        }
+                                                }
+                                                else {
+                                                        tileChain.setBrightness(mBrightness);
+                                                }
+                                        }
+                                        else {
+                                                mLight.setBrightness(mBrightness);
+                                        }
+                                }
+                                else {
+                                        mLight.setColor(mColor, 0, false);
+                                }
 				if (isAutoOn()) {
 					mLight.setPower(true, 0, false);
 				}
@@ -416,17 +442,20 @@ public class GroupViewModel extends MainViewModel {
 					}
 				}
 			}
-			if (color != null) {
-				model.mColor.postValue(color);
-			}
-			if (isAutoOn()) {
-				model.updatePowerButton(Power.ON);
-				DeviceAdapter adapter = model.mAdapter.get();
-				if (adapter != null) {
-					adapter.refreshGroupPower(model.getGroupId(), Power.ON);
-					adapter.refreshGroupColor(model.getGroupId(), color);
-				}
-			}
+                        if (color != null) {
+                                model.mColor.postValue(color);
+                        }
+                        DeviceAdapter adapter = model.mAdapter.get();
+                        if (adapter != null && mColor == null) {
+                                adapter.refreshGroupBrightness(model.getGroupId(), mBrightness);
+                        }
+                        if (isAutoOn()) {
+                                model.updatePowerButton(Power.ON);
+                                if (adapter != null) {
+                                        adapter.refreshGroupPower(model.getGroupId(), Power.ON);
+                                        adapter.refreshGroupColor(model.getGroupId(), color);
+                                }
+                        }
 		}
 
 		@Override

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/MultizoneViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/MultizoneViewModel.java
@@ -110,11 +110,14 @@ public class MultizoneViewModel extends LightViewModel {
 		}
 	}
 
-	@Override
-	public final void updateStoredColor(final Color color) {
-		super.updateStoredColor(color);
-		updateStoredColors(new MultizoneColors.Fixed(color), 1);
-	}
+        @Override
+        public final void updateStoredColor(final Color color) {
+                if (color == null) {
+                        return;
+                }
+                super.updateStoredColor(color);
+                updateStoredColors(new MultizoneColors.Fixed(color), 1);
+        }
 
 	@Override
 	public final void updateColor(final Color color, final boolean isImmediate) {
@@ -147,29 +150,38 @@ public class MultizoneViewModel extends LightViewModel {
 	 * @param isImmediate      Flag indicating if the change should be immediate.
 	 * @param stopAnimation    Flag indicating if animation should be stopped.
 	 */
-	public void updateColors(final MultizoneColors colors, final double brightnessFactor, final boolean isImmediate, final boolean stopAnimation) {
-		updateStoredColors(colors, brightnessFactor);
-		if (stopAnimation) {
-			stopAnimationOrAlarm();
-		}
-		synchronized (mRunningSetColorTasks) {
-			mRunningSetColorTasks.add(new SetMultizoneColorsTask(this, colors.withRelativeBrightness(brightnessFactor), isImmediate));
-			if (mRunningSetColorTasks.size() > 2) {
-				mRunningSetColorTasks.remove(1);
-			}
-			if (mRunningSetColorTasks.size() == 1) {
-				mRunningSetColorTasks.get(0).execute();
-			}
-		}
-	}
+        public void updateColors(final MultizoneColors colors, final double brightnessFactor, final boolean isImmediate, final boolean stopAnimation) {
+                if (stopAnimation) {
+                        stopAnimationOrAlarm();
+                }
+                synchronized (mRunningSetColorTasks) {
+                        if (colors == null) {
+                                mRelativeBrightness.postValue(brightnessFactor);
+                                mRunningSetColorTasks.add(new SetMultizoneColorsTask(this, brightnessFactor, isImmediate));
+                        }
+                        else {
+                                updateStoredColors(colors, brightnessFactor);
+                                mRunningSetColorTasks.add(new SetMultizoneColorsTask(this, colors.withRelativeBrightness(brightnessFactor), isImmediate));
+                        }
+                        if (mRunningSetColorTasks.size() > 2) {
+                                mRunningSetColorTasks.remove(1);
+                        }
+                        if (mRunningSetColorTasks.size() == 1) {
+                                mRunningSetColorTasks.get(0).execute();
+                        }
+                }
+        }
 
 	@Override
-	protected final void doUpdateBrightness(final double brightness) {
-		MultizoneColors oldColors = mColors.getValue();
-		if (oldColors != null) {
-			updateColors(oldColors, brightness, true, false);
-		}
-	}
+        protected final void doUpdateBrightness(final double brightness) {
+                MultizoneColors oldColors = mColors.getValue();
+                if (LifxAnimationService.getAnimationStatus(getLight().getTargetAddress()) == AnimationStatus.NATIVE) {
+                        updateColors(null, brightness, true, false);
+                }
+                else if (oldColors != null) {
+                        updateColors(oldColors, brightness, true, false);
+                }
+        }
 
 	@Override
 	public final void checkColor() {
@@ -301,59 +313,83 @@ public class MultizoneViewModel extends LightViewModel {
 	/**
 	 * An async task for setting the multizone colors.
 	 */
-	private static final class SetMultizoneColorsTask extends AsyncTask<MultizoneColors, String, MultizoneColors> implements AsyncExecutable {
-		/**
-		 * A weak reference to the underlying model.
-		 */
-		private final WeakReference<MultizoneViewModel> mModel;
-		/**
-		 * The colors to be set.
-		 */
-		private final MultizoneColors mColors;
-		/**
-		 * Flag indicating if the change should be immediate.
-		 */
-		private final boolean mIsImmediate;
+        private static final class SetMultizoneColorsTask extends AsyncTask<MultizoneColors, String, MultizoneColors> implements AsyncExecutable {
+                /**
+                 * A weak reference to the underlying model.
+                 */
+                private final WeakReference<MultizoneViewModel> mModel;
+                /**
+                 * The colors to be set.
+                 */
+                private final MultizoneColors mColors;
+                /**
+                 * The brightness to be set.
+                 */
+                private final Double mBrightness;
+                /**
+                 * Flag indicating if the change should be immediate.
+                 */
+                private final boolean mIsImmediate;
 
-		/**
-		 * Constructor.
-		 *
-		 * @param model       The underlying model.
-		 * @param colors      The colors.
-		 * @param isImmediate Flag indicating if the change should be immediate.
-		 */
-		@SuppressWarnings("deprecation")
-		private SetMultizoneColorsTask(final MultizoneViewModel model, final MultizoneColors colors, final boolean isImmediate) {
-			mModel = new WeakReference<>(model);
-			mColors = colors;
-			mIsImmediate = isImmediate;
-		}
+                /**
+                 * Constructor.
+                 *
+                 * @param model       The underlying model.
+                 * @param colors      The colors.
+                 * @param isImmediate Flag indicating if the change should be immediate.
+                 */
+                @SuppressWarnings("deprecation")
+                private SetMultizoneColorsTask(final MultizoneViewModel model, final MultizoneColors colors, final boolean isImmediate) {
+                        mModel = new WeakReference<>(model);
+                        mColors = colors;
+                        mBrightness = null;
+                        mIsImmediate = isImmediate;
+                }
+
+                /**
+                 * Constructor, passing only brightness.
+                 *
+                 * @param model       The underlying model.
+                 * @param brightness  The brightness.
+                 * @param isImmediate Flag indicating if the change should be immediate.
+                 */
+                @SuppressWarnings("deprecation")
+                private SetMultizoneColorsTask(final MultizoneViewModel model, final double brightness, final boolean isImmediate) {
+                        mModel = new WeakReference<>(model);
+                        mColors = null;
+                        mBrightness = brightness;
+                        mIsImmediate = isImmediate;
+                }
 
 		@Override
-		protected MultizoneColors doInBackground(final MultizoneColors... colors) {
-			MultizoneViewModel model = mModel.get();
-			if (model == null) {
-				return null;
-			}
+                protected MultizoneColors doInBackground(final MultizoneColors... colors) {
+                        MultizoneViewModel model = mModel.get();
+                        if (model == null) {
+                                return null;
+                        }
 
-			try {
-				int colorDuration = mIsImmediate ? 0
-						: PreferenceUtil.getSharedPreferenceIntString(
-						R.string.key_pref_color_duration, R.string.pref_default_color_duration);
-				if (model.mPower.getValue() != null && model.mPower.getValue().isOff() && isAutoOn()) {
-					model.getLight().setColors(mColors, 0, false);
-					model.getLight().setPower(true, colorDuration, false);
-				}
-				else {
-					model.getLight().setColors(mColors, colorDuration, false);
-				}
-				return mColors;
-			}
-			catch (IOException e) {
-				Log.w(Application.TAG, e);
-				return null;
-			}
-		}
+                        try {
+                                int colorDuration = mIsImmediate ? 0
+                                                : PreferenceUtil.getSharedPreferenceIntString(
+                                                R.string.key_pref_color_duration, R.string.pref_default_color_duration);
+                                if (mColors == null) {
+                                        model.getLight().setBrightness(mBrightness);
+                                        return null;
+                                }
+                                else if (model.mPower.getValue() != null && model.mPower.getValue().isOff() && isAutoOn()) {
+                                        model.getLight().setColors(mColors, 0, false);
+                                        model.getLight().setPower(true, colorDuration, false);
+                                }
+                                else {
+                                        model.getLight().setColors(mColors, colorDuration, false);
+                                }
+                                return mColors;
+                        }
+                        catch (IOException e) {
+                                Log.w(Application.TAG, e);
+                                return null;
+                        }
+                }
 
 		@Override
 		protected void onPostExecute(final MultizoneColors color) {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
@@ -95,11 +95,14 @@ public class TileViewModel extends LightViewModel {
 		}
 	}
 
-	@Override
-	public final void updateStoredColor(final Color color) {
-		super.updateStoredColor(color);
-		updateStoredColors(new TileChainColors.Fixed(color), 1);
-	}
+        @Override
+        public final void updateStoredColor(final Color color) {
+                if (color == null) {
+                        return;
+                }
+                super.updateStoredColor(color);
+                updateStoredColors(new TileChainColors.Fixed(color), 1);
+        }
 
 	@Override
 	public final void updateColor(final Color color, final boolean isImmediate) {


### PR DESCRIPTION
## Summary
- avoid null group color from corrupting device state
- support brightness-only updates for multizone lights during native animations
- update ColorCycle to honor runtime brightness changes

## Testing
- `gradle test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f8ac1b8c83228d49386c86426293