### PR TITLE
Enable brightness adjustment for color cycle animations

### DIFF
--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -128,12 +128,27 @@ public class LightViewModel extends DeviceViewModel {
 	}
 
 	@Override
-	public final void updateBrightness(final double brightness) {
-		updateSelectedBrightness(brightness);
-		if (LifxAnimationService.getAnimationStatus(getLight().getTargetAddress()) != AnimationStatus.CUSTOM) {
-			doUpdateBrightness(brightness);
-		}
-	}
+        public final void updateBrightness(final double brightness) {
+                updateSelectedBrightness(brightness);
+                AnimationStatus status = LifxAnimationService.getAnimationStatus(getLight().getTargetAddress());
+                if (status != AnimationStatus.CUSTOM) {
+                        doUpdateBrightness(brightness);
+                }
+                else {
+                        AnimationData animationData = LifxAnimationService.getAnimationData(getLight().getTargetAddress());
+                        if (animationData instanceof ColorCycle) {
+                                synchronized (mRunningSetColorTasks) {
+                                        mRunningSetColorTasks.add(new SetBrightnessTask(this, brightness));
+                                        if (mRunningSetColorTasks.size() > 2) {
+                                                mRunningSetColorTasks.remove(1);
+                                        }
+                                        if (mRunningSetColorTasks.size() == 1) {
+                                                mRunningSetColorTasks.get(0).execute();
+                                        }
+                                }
+                        }
+                }
+        }
 
 	/**
 	 * Update the brightness on the light.
@@ -328,11 +343,11 @@ public class LightViewModel extends DeviceViewModel {
 	/**
 	 * An async task for setting the color.
 	 */
-	private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
-		/**
-		 * A weak reference to the underlying model.
-		 */
-		private final WeakReference<LightViewModel> mModel;
+        private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
+                /**
+                 * A weak reference to the underlying model.
+                 */
+                private final WeakReference<LightViewModel> mModel;
 		/**
 		 * The color to be set.
 		 */
@@ -379,11 +394,11 @@ public class LightViewModel extends DeviceViewModel {
 			catch (IOException e) {
 				Log.w(Application.TAG, e);
 				return null;
-			}
-		}
+                }
+        }
 
-		@Override
-		protected void onPostExecute(final Color color) {
+                @Override
+                protected void onPostExecute(final Color color) {
 			LightViewModel model = mModel.get();
 			if (model == null) {
 				return;
@@ -401,8 +416,72 @@ public class LightViewModel extends DeviceViewModel {
 		}
 
 		@Override
-		public void execute() {
-			executeOnExecutor(THREAD_POOL_EXECUTOR);
-		}
-	}
+                public void execute() {
+                        executeOnExecutor(THREAD_POOL_EXECUTOR);
+                }
+        }
+
+        /**
+         * Async task for setting the brightness without stopping animations.
+         */
+        private static final class SetBrightnessTask extends AsyncTask<Double, String, Void> implements AsyncExecutable {
+                /**
+                 * A weak reference to the underlying model.
+                 */
+                private final WeakReference<LightViewModel> mModel;
+                /**
+                 * The brightness to be set.
+                 */
+                private final double mBrightness;
+
+                /**
+                 * Constructor.
+                 *
+                 * @param model      The underlying model.
+                 * @param brightness The brightness.
+                 */
+                @SuppressWarnings("deprecation")
+                private SetBrightnessTask(final LightViewModel model, final double brightness) {
+                        mModel = new WeakReference<>(model);
+                        mBrightness = brightness;
+                }
+
+                @Override
+                protected Void doInBackground(final Double... doubles) {
+                        LightViewModel model = mModel.get();
+                        if (model == null) {
+                                return null;
+                        }
+                        try {
+                                model.getLight().setBrightness(mBrightness);
+                        }
+                        catch (IOException e) {
+                                Log.w(Application.TAG, e);
+                        }
+                        return null;
+                }
+
+                @Override
+                protected void onPostExecute(final Void aVoid) {
+                        LightViewModel model = mModel.get();
+                        if (model == null) {
+                                return;
+                        }
+                        synchronized (model.mRunningSetColorTasks) {
+                                model.mRunningSetColorTasks.remove(this);
+                                if (!model.mRunningSetColorTasks.isEmpty()) {
+                                        model.mRunningSetColorTasks.get(0).execute();
+                                }
+                        }
+                        Color oldColor = model.mColor.getValue();
+                        if (oldColor != null) {
+                                model.updateStoredColor(oldColor.withBrightness(mBrightness));
+                        }
+                }
+
+                @Override
+                public void execute() {
+                        executeOnExecutor(THREAD_POOL_EXECUTOR);
+                }
+        }
 }

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -127,32 +127,14 @@ public class LightViewModel extends DeviceViewModel {
 		updateColor(newColor, true);
 	}
 
-	@Override
+        @Override
         public final void updateBrightness(final double brightness) {
                 updateSelectedBrightness(brightness);
-                AnimationStatus status = LifxAnimationService.getAnimationStatus(getLight().getTargetAddress());
-                if (status != AnimationStatus.CUSTOM) {
+                String mac = getLight().getTargetAddress();
+                AnimationStatus status = LifxAnimationService.getAnimationStatus(mac);
+                if (status != AnimationStatus.CUSTOM
+                                || LifxAnimationService.getAnimationData(mac) instanceof ColorCycle) {
                         doUpdateBrightness(brightness);
-                }
-                else {
-                        AnimationData animationData = LifxAnimationService.getAnimationData(getLight().getTargetAddress());
-                        if (animationData instanceof ColorCycle) {
-                                if (getLight().getProduct().isMatrix() && !getLight().getProduct().isChain()
-                                                && this instanceof TileViewModel) {
-                                        ((TileViewModel) this).updateBrightnessForCurrentColors(brightness);
-                                }
-                                else {
-                                        synchronized (mRunningSetColorTasks) {
-                                                mRunningSetColorTasks.add(new SetBrightnessTask(this, brightness));
-                                                if (mRunningSetColorTasks.size() > 2) {
-                                                        mRunningSetColorTasks.remove(1);
-                                                }
-                                                if (mRunningSetColorTasks.size() == 1) {
-                                                        mRunningSetColorTasks.get(0).execute();
-                                                }
-                                        }
-                                }
-                        }
                 }
         }
 
@@ -349,11 +331,11 @@ public class LightViewModel extends DeviceViewModel {
 	/**
 	 * An async task for setting the color.
 	 */
-        private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
-                /**
-                 * A weak reference to the underlying model.
-                 */
-                private final WeakReference<LightViewModel> mModel;
+	private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
+		/**
+		 * A weak reference to the underlying model.
+		 */
+		private final WeakReference<LightViewModel> mModel;
 		/**
 		 * The color to be set.
 		 */
@@ -400,11 +382,11 @@ public class LightViewModel extends DeviceViewModel {
 			catch (IOException e) {
 				Log.w(Application.TAG, e);
 				return null;
-                }
-        }
+			}
+		}
 
-                @Override
-                protected void onPostExecute(final Color color) {
+		@Override
+		protected void onPostExecute(final Color color) {
 			LightViewModel model = mModel.get();
 			if (model == null) {
 				return;
@@ -422,72 +404,8 @@ public class LightViewModel extends DeviceViewModel {
 		}
 
 		@Override
-                public void execute() {
-                        executeOnExecutor(THREAD_POOL_EXECUTOR);
-                }
-        }
-
-        /**
-         * Async task for setting the brightness without stopping animations.
-         */
-        private static final class SetBrightnessTask extends AsyncTask<Double, String, Void> implements AsyncExecutable {
-                /**
-                 * A weak reference to the underlying model.
-                 */
-                private final WeakReference<LightViewModel> mModel;
-                /**
-                 * The brightness to be set.
-                 */
-                private final double mBrightness;
-
-                /**
-                 * Constructor.
-                 *
-                 * @param model      The underlying model.
-                 * @param brightness The brightness.
-                 */
-                @SuppressWarnings("deprecation")
-                private SetBrightnessTask(final LightViewModel model, final double brightness) {
-                        mModel = new WeakReference<>(model);
-                        mBrightness = brightness;
-                }
-
-                @Override
-                protected Void doInBackground(final Double... doubles) {
-                        LightViewModel model = mModel.get();
-                        if (model == null) {
-                                return null;
-                        }
-                        try {
-                                model.getLight().setBrightness(mBrightness);
-                        }
-                        catch (IOException e) {
-                                Log.w(Application.TAG, e);
-                        }
-                        return null;
-                }
-
-                @Override
-                protected void onPostExecute(final Void aVoid) {
-                        LightViewModel model = mModel.get();
-                        if (model == null) {
-                                return;
-                        }
-                        synchronized (model.mRunningSetColorTasks) {
-                                model.mRunningSetColorTasks.remove(this);
-                                if (!model.mRunningSetColorTasks.isEmpty()) {
-                                        model.mRunningSetColorTasks.get(0).execute();
-                                }
-                        }
-                        Color oldColor = model.mColor.getValue();
-                        if (oldColor != null) {
-                                model.updateStoredColor(oldColor.withBrightness(mBrightness));
-                        }
-                }
-
-                @Override
-                public void execute() {
-                        executeOnExecutor(THREAD_POOL_EXECUTOR);
-                }
-        }
+		public void execute() {
+			executeOnExecutor(THREAD_POOL_EXECUTOR);
+		}
+	}
 }

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -137,13 +137,19 @@ public class LightViewModel extends DeviceViewModel {
                 else {
                         AnimationData animationData = LifxAnimationService.getAnimationData(getLight().getTargetAddress());
                         if (animationData instanceof ColorCycle) {
-                                synchronized (mRunningSetColorTasks) {
-                                        mRunningSetColorTasks.add(new SetBrightnessTask(this, brightness));
-                                        if (mRunningSetColorTasks.size() > 2) {
-                                                mRunningSetColorTasks.remove(1);
-                                        }
-                                        if (mRunningSetColorTasks.size() == 1) {
-                                                mRunningSetColorTasks.get(0).execute();
+                                if (getLight().getProduct().isMatrix() && !getLight().getProduct().isChain()
+                                                && this instanceof TileViewModel) {
+                                        ((TileViewModel) this).updateBrightnessForCurrentColors(brightness);
+                                }
+                                else {
+                                        synchronized (mRunningSetColorTasks) {
+                                                mRunningSetColorTasks.add(new SetBrightnessTask(this, brightness));
+                                                if (mRunningSetColorTasks.size() > 2) {
+                                                        mRunningSetColorTasks.remove(1);
+                                                }
+                                                if (mRunningSetColorTasks.size() == 1) {
+                                                        mRunningSetColorTasks.get(0).execute();
+                                                }
                                         }
                                 }
                         }

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/LightViewModel.java
@@ -132,9 +132,18 @@ public class LightViewModel extends DeviceViewModel {
                 updateSelectedBrightness(brightness);
                 String mac = getLight().getTargetAddress();
                 AnimationStatus status = LifxAnimationService.getAnimationStatus(mac);
-                if (status != AnimationStatus.CUSTOM
-                                || LifxAnimationService.getAnimationData(mac) instanceof ColorCycle) {
-                        doUpdateBrightness(brightness);
+                AnimationData animationData = LifxAnimationService.getAnimationData(mac);
+                if (status == AnimationStatus.CUSTOM && !(animationData instanceof ColorCycle)) {
+                        return;
+                }
+                synchronized (mRunningSetColorTasks) {
+                        mRunningSetColorTasks.add(new SetBrightnessTask(this, brightness));
+                        if (mRunningSetColorTasks.size() > 2) {
+                                mRunningSetColorTasks.remove(1);
+                        }
+                        if (mRunningSetColorTasks.size() == 1) {
+                                mRunningSetColorTasks.get(0).execute();
+                        }
                 }
         }
 
@@ -290,10 +299,10 @@ public class LightViewModel extends DeviceViewModel {
 		getLight().endAnimation(false);
 	}
 
-	/**
-	 * An async task for checking the color.
-	 */
-	private static final class CheckColorTask extends AsyncTask<String, String, Color> {
+        /**
+         * An async task for checking the color.
+         */
+        private static final class CheckColorTask extends AsyncTask<String, String, Color> {
 		/**
 		 * A weak reference to the underlying model.
 		 */
@@ -326,12 +335,67 @@ public class LightViewModel extends DeviceViewModel {
 			}
 			model.updateStoredColor(color);
 		}
-	}
+        }
 
-	/**
-	 * An async task for setting the color.
-	 */
-	private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
+        /**
+         * An async task for setting the brightness.
+         */
+        private static final class SetBrightnessTask extends AsyncTask<Double, String, Void> implements AsyncExecutable {
+                /**
+                 * A weak reference to the underlying model.
+                 */
+                private final WeakReference<LightViewModel> mModel;
+                /**
+                 * The brightness to be set.
+                 */
+                private final double mBrightness;
+
+                /**
+                 * Constructor.
+                 *
+                 * @param model      The underlying model.
+                 * @param brightness The brightness.
+                 */
+                @SuppressWarnings("deprecation")
+                private SetBrightnessTask(final LightViewModel model, final double brightness) {
+                        mModel = new WeakReference<>(model);
+                        mBrightness = brightness;
+                }
+
+                @Override
+                protected Void doInBackground(final Double... brightness) {
+                        LightViewModel model = mModel.get();
+                        if (model == null) {
+                                return null;
+                        }
+                        model.doUpdateBrightness(mBrightness);
+                        return null;
+                }
+
+                @Override
+                protected void onPostExecute(final Void aVoid) {
+                        LightViewModel model = mModel.get();
+                        if (model == null) {
+                                return;
+                        }
+                        synchronized (model.mRunningSetColorTasks) {
+                                model.mRunningSetColorTasks.remove(this);
+                                if (!model.mRunningSetColorTasks.isEmpty()) {
+                                        model.mRunningSetColorTasks.get(0).execute();
+                                }
+                        }
+                }
+
+                @Override
+                public void execute() {
+                        executeOnExecutor(THREAD_POOL_EXECUTOR);
+                }
+        }
+
+        /**
+         * An async task for setting the color.
+         */
+        private static final class SetColorTask extends AsyncTask<Color, String, Color> implements AsyncExecutable {
 		/**
 		 * A weak reference to the underlying model.
 		 */

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
@@ -111,10 +111,27 @@ public class TileViewModel extends LightViewModel {
 	}
 
 	@Override
-	public final void updateSelectedBrightness(final double brightness) {
-		super.updateSelectedBrightness(brightness);
-		mRelativeBrightness.postValue(brightness);
-	}
+        public final void updateSelectedBrightness(final double brightness) {
+                super.updateSelectedBrightness(brightness);
+                mRelativeBrightness.postValue(brightness);
+        }
+
+        /**
+         * Update brightness while keeping the current colors.
+         *
+         * @param brightness The new brightness.
+         */
+        void updateBrightnessForCurrentColors(final double brightness) {
+                synchronized (mRunningSetColorTasks) {
+                        mRunningSetColorTasks.add(new SetTileBrightnessTask(this, brightness));
+                        if (mRunningSetColorTasks.size() > 2) {
+                                mRunningSetColorTasks.remove(1);
+                        }
+                        if (mRunningSetColorTasks.size() == 1) {
+                                mRunningSetColorTasks.get(0).execute();
+                        }
+                }
+        }
 
 	/**
 	 * Update the main color for color pickers.
@@ -379,9 +396,77 @@ public class TileViewModel extends LightViewModel {
 		}
 
 		@Override
-		public void execute() {
-			executeOnExecutor(THREAD_POOL_EXECUTOR);
-		}
-	}
+                public void execute() {
+                        executeOnExecutor(THREAD_POOL_EXECUTOR);
+                }
+        }
+
+        /**
+         * Async task for setting brightness while preserving current tile colors.
+         */
+        private static final class SetTileBrightnessTask extends AsyncTask<Double, String, TileChainColors> implements AsyncExecutable {
+                /**
+                 * A weak reference to the underlying model.
+                 */
+                private final WeakReference<TileViewModel> mModel;
+                /**
+                 * The brightness to be applied.
+                 */
+                private final double mBrightness;
+
+                /**
+                 * Constructor.
+                 *
+                 * @param model      The underlying model.
+                 * @param brightness The brightness.
+                 */
+                @SuppressWarnings("deprecation")
+                private SetTileBrightnessTask(final TileViewModel model, final double brightness) {
+                        mModel = new WeakReference<>(model);
+                        mBrightness = brightness;
+                }
+
+                @Override
+                protected TileChainColors doInBackground(final Double... doubles) {
+                        TileViewModel model = mModel.get();
+                        if (model == null) {
+                                return null;
+                        }
+                        try {
+                                TileChainColors colors = model.getLight().getColors();
+                                if (colors != null) {
+                                        colors = colors.withRelativeBrightness(mBrightness);
+                                        model.getLight().setColors(colors, 0, false);
+                                }
+                                return colors;
+                        }
+                        catch (IOException e) {
+                                Log.w(Application.TAG, e);
+                                return null;
+                        }
+                }
+
+                @Override
+                protected void onPostExecute(final TileChainColors colors) {
+                        TileViewModel model = mModel.get();
+                        if (model == null) {
+                                return;
+                        }
+                        synchronized (model.mRunningSetColorTasks) {
+                                model.mRunningSetColorTasks.remove(this);
+                                if (!model.mRunningSetColorTasks.isEmpty()) {
+                                        model.mRunningSetColorTasks.get(0).execute();
+                                }
+                        }
+                        if (colors != null) {
+                                model.updateStoredColors(colors, mBrightness);
+                        }
+                }
+
+                @Override
+                public void execute() {
+                        executeOnExecutor(THREAD_POOL_EXECUTOR);
+                }
+        }
 
 }

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
@@ -157,18 +157,19 @@ public class TileViewModel extends LightViewModel {
 		}
 	}
 
-	@Override
-	protected final void doUpdateBrightness(final double brightness) {
-		TileChainColors oldColors = mColors.getValue();
-		if (oldColors != null) {
-			if (LifxAnimationService.getAnimationStatus(getLight().getTargetAddress()) == AnimationStatus.NATIVE && getDevice().getProduct().isChain()) {
-				updateColors(null, brightness, true, false);
-			}
-			else {
-				updateColors(oldColors, brightness, true, false);
-			}
-		}
-	}
+        @Override
+        protected final void doUpdateBrightness(final double brightness) {
+                TileChainColors oldColors = mColors.getValue();
+                if (oldColors != null) {
+                        if (!getDevice().getProduct().isChain()
+                                        || LifxAnimationService.getAnimationStatus(getLight().getTargetAddress()) == AnimationStatus.NATIVE) {
+                                updateColors(null, brightness, true, false);
+                        }
+                        else {
+                                updateColors(oldColors, brightness, true, false);
+                        }
+                }
+        }
 
 	@Override
 	public final void checkColor() {

--- a/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
+++ b/LifxTools/app/src/main/java/de/jeisfeld/lifx/app/home/TileViewModel.java
@@ -111,27 +111,10 @@ public class TileViewModel extends LightViewModel {
 	}
 
 	@Override
-        public final void updateSelectedBrightness(final double brightness) {
-                super.updateSelectedBrightness(brightness);
-                mRelativeBrightness.postValue(brightness);
-        }
-
-        /**
-         * Update brightness while keeping the current colors.
-         *
-         * @param brightness The new brightness.
-         */
-        void updateBrightnessForCurrentColors(final double brightness) {
-                synchronized (mRunningSetColorTasks) {
-                        mRunningSetColorTasks.add(new SetTileBrightnessTask(this, brightness));
-                        if (mRunningSetColorTasks.size() > 2) {
-                                mRunningSetColorTasks.remove(1);
-                        }
-                        if (mRunningSetColorTasks.size() == 1) {
-                                mRunningSetColorTasks.get(0).execute();
-                        }
-                }
-        }
+	public final void updateSelectedBrightness(final double brightness) {
+		super.updateSelectedBrightness(brightness);
+		mRelativeBrightness.postValue(brightness);
+	}
 
 	/**
 	 * Update the main color for color pickers.
@@ -396,77 +379,9 @@ public class TileViewModel extends LightViewModel {
 		}
 
 		@Override
-                public void execute() {
-                        executeOnExecutor(THREAD_POOL_EXECUTOR);
-                }
-        }
-
-        /**
-         * Async task for setting brightness while preserving current tile colors.
-         */
-        private static final class SetTileBrightnessTask extends AsyncTask<Double, String, TileChainColors> implements AsyncExecutable {
-                /**
-                 * A weak reference to the underlying model.
-                 */
-                private final WeakReference<TileViewModel> mModel;
-                /**
-                 * The brightness to be applied.
-                 */
-                private final double mBrightness;
-
-                /**
-                 * Constructor.
-                 *
-                 * @param model      The underlying model.
-                 * @param brightness The brightness.
-                 */
-                @SuppressWarnings("deprecation")
-                private SetTileBrightnessTask(final TileViewModel model, final double brightness) {
-                        mModel = new WeakReference<>(model);
-                        mBrightness = brightness;
-                }
-
-                @Override
-                protected TileChainColors doInBackground(final Double... doubles) {
-                        TileViewModel model = mModel.get();
-                        if (model == null) {
-                                return null;
-                        }
-                        try {
-                                TileChainColors colors = model.getLight().getColors();
-                                if (colors != null) {
-                                        colors = colors.withRelativeBrightness(mBrightness);
-                                        model.getLight().setColors(colors, 0, false);
-                                }
-                                return colors;
-                        }
-                        catch (IOException e) {
-                                Log.w(Application.TAG, e);
-                                return null;
-                        }
-                }
-
-                @Override
-                protected void onPostExecute(final TileChainColors colors) {
-                        TileViewModel model = mModel.get();
-                        if (model == null) {
-                                return;
-                        }
-                        synchronized (model.mRunningSetColorTasks) {
-                                model.mRunningSetColorTasks.remove(this);
-                                if (!model.mRunningSetColorTasks.isEmpty()) {
-                                        model.mRunningSetColorTasks.get(0).execute();
-                                }
-                        }
-                        if (colors != null) {
-                                model.updateStoredColors(colors, mBrightness);
-                        }
-                }
-
-                @Override
-                public void execute() {
-                        executeOnExecutor(THREAD_POOL_EXECUTOR);
-                }
-        }
+		public void execute() {
+			executeOnExecutor(THREAD_POOL_EXECUTOR);
+		}
+	}
 
 }


### PR DESCRIPTION
## Summary
- Allow brightness slider changes during color cycle animations by queuing asynchronous brightness updates
- Introduce SetBrightnessTask to apply brightness without stopping ongoing animations

## Testing
- `./gradlew test` *(fails: Could not find or load main class org.gradle.wrapper.GradleWrapperMain)*

------
https://chatgpt.com/codex/tasks/task_e_68c72e5c1a3883229fdb91cfdfd0c6b1